### PR TITLE
Ensure HTML errors are returned as comments

### DIFF
--- a/src/routers/placement.js
+++ b/src/routers/placement.js
@@ -14,7 +14,7 @@ const handleError = (err, req, res) => {
   const status = err.status || err.statusCode || 500;
   const message = err.expose ? err.message : 'A fatal error has occurred.';
   res.set('Content-Type', 'text/html');
-  let response = `${message} (${status})`;
+  let response = `<!-- ${message} (${status}) -->`;
   if (extension === 'json') {
     response = { error: { status, message } };
     res.set('Content-Type', 'application/json');

--- a/test/routers/placement.spec.js
+++ b/test/routers/placement.spec.js
@@ -147,7 +147,7 @@ describe('routers/placement', function() {
           .expect((res) => {
             const { status, text } = res;
             expect(status).to.equal(400);
-            expect(text).to.equal('The requested file extension is not supported. (400)');
+            expect(text).to.equal('<!-- The requested file extension is not supported. (400) -->');
           })
           .end(done);
       });
@@ -161,7 +161,7 @@ describe('routers/placement', function() {
         .expect((res) => {
           const { status, text } = res;
           expect(status).to.equal(400);
-          expect(text).to.equal('No template ID was provided. (400)');
+          expect(text).to.equal('<!-- No template ID was provided. (400) -->');
         })
         .end(done);
     });


### PR DESCRIPTION
HTML ad request errors will now return as HTML comments. This prevents an error from displaying within the requesting website.