### PR TITLE
Update image beacons to contain correct attributes

### DIFF
--- a/src/repositories/campaign/placement.js
+++ b/src/repositories/campaign/placement.js
@@ -117,7 +117,7 @@ module.exports = {
   },
 
   createImgBeacon(trackers) {
-    return `<div data-app="fortnight" data-type="placement"><img src="${trackers.load}" data-view-src="${trackers.view}"></div>`;
+    return `<div data-fortnight-type="placement"><img data-fortnight-view="pending" data-fortnight-beacon="${trackers.view}" src="${trackers.load}"></div>`;
   },
 
   createTrackedHTML(ad) {

--- a/test/routers/placement.spec.js
+++ b/test/routers/placement.spec.js
@@ -63,7 +63,7 @@ describe('routers/placement', function() {
         .expect('Content-Type', /text\/html/)
         .expect(200)
         .expect((res) => {
-          expect(res.text).to.contain('<div data-app="fortnight" data-type="placement">');
+          expect(res.text).to.contain('<div data-fortnight-type="placement"><img data-fortnight-view="pending" data-fortnight-beacon="');
         })
         .end(done);
     });


### PR DESCRIPTION
Image beacons now contain the correct data attributes needed for in-view tracking.

Example: `<div data-fortnight-type="placement"><img data-fortnight-view="pending" data-fortnight-beacon="${trackers.view}" src="${trackers.load}"></div>`