### PR TITLE
Wrap New Relic and only enable on production

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 require('dotenv').config();
-
-/* istanbul ignore if  */
-if (process.env.NEW_RELIC_LICENSE_KEY) require('newrelic'); // eslint-disable-line global-require
+require('./newrelic');
 
 const pkg = require('../package.json');
 const { app } = require('./server');

--- a/src/newrelic.js
+++ b/src/newrelic.js
@@ -1,0 +1,6 @@
+/* istanbul ignore if  */
+if (process.env.NODE_ENV !== 'production') process.env.NEW_RELIC_ENABLED = false;
+
+const newrelic = require('newrelic');
+
+module.exports = newrelic;

--- a/src/routers/placement.js
+++ b/src/routers/placement.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const helmet = require('helmet');
+const newrelic = require('../newrelic');
 const createError = require('http-errors');
 const CampaignPlacementRepo = require('../repositories/campaign/placement');
 
@@ -9,6 +10,7 @@ router.use(helmet.noCache());
 const acceptable = ['json', 'html'];
 
 const handleError = (err, req, res) => {
+  newrelic.noticeError(err);
   const { ext } = req.params;
   const extension = acceptable.includes(ext) ? ext : 'html';
   const status = err.status || err.statusCode || 500;


### PR DESCRIPTION
The New Relic agent is now wrapped within the `/src/newrelic.js` application file. This will make NR available throughout the app, but will only enable it if in production, per the [agent config docs](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration).

**Note**: you must utilize the application NR file  and not the default module when requiring. For example, instead of including `const newrelic = require('newrelic');` you must use `const newrelic = require('./newrelic');` instead. Note: the file path is relative to the requiring file.

Resolves #46 