### PR TITLE
Save creative ID to analytics event

### DIFF
--- a/src/services/event-handler.js
+++ b/src/services/event-handler.js
@@ -36,7 +36,7 @@ module.exports = {
 
     let creativeId;
     if (cid) {
-      const campaign = await Campaign.findOne({ _id: cid }, { _id: 1, creatives: 1 });
+      const campaign = await Campaign.findOne({ _id: cid }, { _id: 1, 'creatives._id': 1 });
       if (!campaign) throw new Error(`No campaign was found for id '${cid}'`);
       if (cre) {
         const creative = campaign.creatives.id(cre);

--- a/test/services/event-handler.spec.js
+++ b/test/services/event-handler.spec.js
@@ -119,6 +119,7 @@ describe('services/event-handler', function() {
         pid: placement.id,
         uuid:'db1a4977-6ef8-4039-959d-99f95b839eae',
         cid: campaign.id,
+        cre: campaign.get('creatives.0.id'),
       };
       const promise = EventHandler.track({ action: 'view', fields });
       await expect(promise).to.be.fulfilled;
@@ -163,6 +164,7 @@ describe('services/event-handler', function() {
         pid: placement.id,
         uuid:'db1a4977-6ef8-4039-959d-99f95b839eae',
         cid: campaign.id,
+        cre: campaign.get('creatives.0.id'),
       };
       const promise = EventHandler.track({ action: 'contextmenu', fields });
       await expect(promise).to.be.fulfilled;
@@ -184,6 +186,7 @@ describe('services/event-handler', function() {
         pid: placement.id,
         uuid:'db1a4977-6ef8-4039-959d-99f95b839eae',
         cid: campaign.id,
+        cre: campaign.get('creatives.0.id'),
       };
       const promise = EventHandler.track({ action: 'load', fields });
       await expect(promise).to.be.fulfilled;
@@ -205,6 +208,7 @@ describe('services/event-handler', function() {
         pid: placement.id,
         uuid:'db1a4977-6ef8-4039-959d-99f95b839eae',
         cid: campaign.id,
+        cre: campaign.get('creatives.0.id'),
       };
       const promise = EventHandler.track({ action: 'click', fields });
       await expect(promise).to.be.fulfilled;


### PR DESCRIPTION
Stores the creative ID (`cre`) field to the `AnalyticsEvent` document.

See #101 