### PR TITLE
Adds `test:watch` command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,6 +41,22 @@ gulp.task('lint', function (cb) {
 
 gulp.task('default', ['watch', 'serve']);
 
+gulp.task('test', function(cb) {
+  if (node) {
+    node.kill();
+  }
+
+  node = spawn('./node_modules/.bin/mocha', ['--reporter', 'min', '--watch'], { stdio: 'inherit' });
+
+  node.on('close', function (code) {
+    if (code === 8) {
+      cb(code);
+      console.log('Error detected, waiting for changes...');
+    }
+  });
+  cb();
+});
+
 // clean up if an error goes unhandled.
 process.on('exit', function () {
   if (node) node.kill()

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "pretest": "yarn run posttest && $npm_package_docker_test_install",
     "posttest": "$npm_package_docker_test_down && $npm_package_docker_test_prune",
     "test": "$npm_package_docker_test_test",
+    "pretest:watch": "yarn run posttest:watch && $npm_package_docker_test_install",
+    "posttest:watch": "$npm_package_docker_test_down && $npm_package_docker_test_prune",
+    "test:watch": "$npm_package_docker_test_watch",
     "prestart": "$npm_package_docker_dev_install",
     "start": "$npm_package_docker_dev_up",
     "stop": "$npm_package_docker_dev_down",
@@ -22,6 +25,7 @@
     "postcoverage": "$npm_package_docker_test_down && $npm_package_docker_test_prune",
     "test:ci": "yarn run lint:run && ./node_modules/.bin/mocha --reporter mocha-junit-reporter --reporter-options mochaFile=./coverage/test-results.xml",
     "test:run": "yarn run lint:run && ./node_modules/.bin/mocha --reporter spec",
+    "test:watch:run": "./node_modules/.bin/mocha --reporter min --watch",
     "lint:run": "./node_modules/.bin/eslint \"src/**/*.js\"",
     "coverage:run": "./node_modules/.bin/nyc yarn run test:ci"
   },
@@ -33,7 +37,8 @@
     },
     "test": {
       "install": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml run --no-deps --entrypoint yarn test",
-      "test": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml run test",
+      "test": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml run --entrypoint yarn test run test:run",
+      "watch": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml run --entrypoint yarn test run test:watch:run",
       "coverage": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml run --entrypoint yarn test run coverage:run",
       "lint": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml run --entrypoint yarn test run lint:run",
       "down": "docker-compose -p fortnightgraphtest -f test/docker-compose.yml down",

--- a/src/connections/mongoose/index.js
+++ b/src/connections/mongoose/index.js
@@ -5,13 +5,16 @@ const { MONGO_DSN, MONGOOSE_DEBUG } = process.env;
 mongoose.set('debug', Boolean(MONGOOSE_DEBUG));
 mongoose.Promise = bluebird;
 
-mongoose.connect(MONGO_DSN, {
+const connection = mongoose.createConnection(MONGO_DSN, {
   // autoIndex: process.env.NODE_ENV !== 'production',
   ignoreUndefined: true,
   promiseLibrary: bluebird,
-}).then(() => {
-  process.stdout.write(`Successful MongoDB connection to '${MONGO_DSN}'\n`);
-  return mongoose;
 });
 
-module.exports = mongoose;
+connection.once('open', () => {
+  if (process.env.NODE_ENV !== 'test') {
+    process.stdout.write(`Successful MongoDB connection to '${MONGO_DSN}'\n`);
+  }
+});
+
+module.exports = connection;

--- a/src/connections/redis/index.js
+++ b/src/connections/redis/index.js
@@ -7,7 +7,9 @@ Promise.promisifyAll(redis.Multi.prototype);
 const options = { url: process.env.REDIS_DSN };
 const client = redis.createClient(options);
 client.on('connect', () => {
-  process.stdout.write(`Successful Redis connection with options '${JSON.stringify(options)}'\n`);
+  if (process.env.NODE_ENV !== 'test') {
+    process.stdout.write(`Successful Redis connection with options '${JSON.stringify(options)}'\n`);
+  }
 });
 
 module.exports = client;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ const { app } = require('./server');
 const { PORT } = process.env;
 
 const server = app.listen(PORT);
-process.stdout.write(`Express app '${pkg.name}' listening on port ${PORT}\n`);
+
+if (process.env.NODE_ENV !== 'test') {
+  process.stdout.write(`Express app '${pkg.name}' listening on port ${PORT}\n`);
+}
 
 module.exports = server;

--- a/src/models/advertiser.js
+++ b/src/models/advertiser.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/advertiser');
 
 module.exports = mongoose.model('advertiser', schema);

--- a/src/models/analytics/bot.js
+++ b/src/models/analytics/bot.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/bot');
 
 module.exports = mongoose.model('analytics-bot', schema);

--- a/src/models/analytics/click.js
+++ b/src/models/analytics/click.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/click');
 
 module.exports = mongoose.model('analytics-click', schema);

--- a/src/models/analytics/event.js
+++ b/src/models/analytics/event.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/event');
 
 module.exports = mongoose.model('analytics-event', schema);

--- a/src/models/analytics/load.js
+++ b/src/models/analytics/load.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/load');
 
 module.exports = mongoose.model('analytics-load', schema);

--- a/src/models/analytics/request-object.js
+++ b/src/models/analytics/request-object.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/request-object');
 
 module.exports = mongoose.model('analytics-request-object', schema);

--- a/src/models/analytics/request.js
+++ b/src/models/analytics/request.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/request');
 
 module.exports = mongoose.model('analytics-request', schema);

--- a/src/models/analytics/view.js
+++ b/src/models/analytics/view.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../../connections/mongoose');
 const schema = require('../../schema/analytics/view');
 
 module.exports = mongoose.model('analytics-view', schema);

--- a/src/models/campaign.js
+++ b/src/models/campaign.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/campaign');
 
 module.exports = mongoose.model('campaign', schema);

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/contact');
 
 module.exports = mongoose.model('contact', schema);

--- a/src/models/placement.js
+++ b/src/models/placement.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/placement');
 
 module.exports = mongoose.model('placement', schema);

--- a/src/models/publisher.js
+++ b/src/models/publisher.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/publisher');
 
 module.exports = mongoose.model('publisher', schema);

--- a/src/models/template.js
+++ b/src/models/template.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/template');
 
 module.exports = mongoose.model('template', schema);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const mongoose = require('../connections/mongoose');
 const schema = require('../schema/user');
 
 module.exports = mongoose.model('user', schema);

--- a/src/repositories/session.js
+++ b/src/repositories/session.js
@@ -3,7 +3,7 @@ const jwt = require('jsonwebtoken');
 const uuidv4 = require('uuid/v4');
 const uuidv5 = require('uuid/v5');
 const bcrypt = require('bcrypt');
-const redis = require('../redis');
+const redis = require('../connections/redis');
 
 const SETTINGS = {
   // @todo Rotate the global secrets?

--- a/src/schema/advertiser.js
+++ b/src/schema/advertiser.js
@@ -1,8 +1,6 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const notifyPlugin = require('../plugins/notify');
 const validator = require('validator');
-
-const { Schema } = mongoose;
 
 const schema = new Schema({
   name: {

--- a/src/schema/analytics/click.js
+++ b/src/schema/analytics/click.js
@@ -1,5 +1,5 @@
-const analyticsPlugin = require('../../plugins/analytics');
 const { Schema } = require('mongoose');
+const analyticsPlugin = require('../../plugins/analytics');
 
 const schema = new Schema({
   cid: {

--- a/src/schema/analytics/load.js
+++ b/src/schema/analytics/load.js
@@ -1,5 +1,5 @@
-const analyticsPlugin = require('../../plugins/analytics');
 const { Schema } = require('mongoose');
+const analyticsPlugin = require('../../plugins/analytics');
 
 const schema = new Schema({
   cid: {

--- a/src/schema/analytics/request.js
+++ b/src/schema/analytics/request.js
@@ -1,5 +1,5 @@
-const analyticsPlugin = require('../../plugins/analytics');
 const { Schema } = require('mongoose');
+const analyticsPlugin = require('../../plugins/analytics');
 
 const schema = new Schema();
 schema.plugin(analyticsPlugin);

--- a/src/schema/analytics/view.js
+++ b/src/schema/analytics/view.js
@@ -1,5 +1,5 @@
-const analyticsPlugin = require('../../plugins/analytics');
 const { Schema } = require('mongoose');
+const analyticsPlugin = require('../../plugins/analytics');
 
 const schema = new Schema({
   cid: {

--- a/src/schema/campaign/creative.js
+++ b/src/schema/campaign/creative.js
@@ -1,7 +1,6 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const ImageSchema = require('./image');
 
-const { Schema } = mongoose;
 
 module.exports = new Schema({
   title: {

--- a/src/schema/campaign/criteria.js
+++ b/src/schema/campaign/criteria.js
@@ -1,7 +1,5 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const Placement = require('../../models/placement');
-
-const { Schema } = mongoose;
 
 module.exports = new Schema({
   start: {

--- a/src/schema/campaign/image-focal-point.js
+++ b/src/schema/campaign/image-focal-point.js
@@ -1,6 +1,4 @@
-const mongoose = require('mongoose');
-
-const { Schema } = mongoose;
+const { Schema } = require('mongoose');
 
 module.exports = new Schema({
   x: {

--- a/src/schema/campaign/image.js
+++ b/src/schema/campaign/image.js
@@ -1,8 +1,6 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const validator = require('validator');
 const FocalPointSchema = require('./image-focal-point');
-
-const { Schema } = mongoose;
 
 module.exports = new Schema({
   src: {

--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const validator = require('validator');
 const CreativeSchema = require('./creative');
 const CriteriaSchema = require('./criteria');
@@ -6,8 +6,6 @@ const Advertiser = require('../../models/advertiser');
 const uuid = require('uuid/v4');
 const uuidParse = require('uuid-parse');
 const notifyPlugin = require('../../plugins/notify');
-
-const { Schema } = mongoose;
 
 const externalLinkSchema = new Schema({
   label: {

--- a/src/schema/contact.js
+++ b/src/schema/contact.js
@@ -1,7 +1,5 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const validator = require('validator');
-
-const { Schema } = mongoose;
 
 const schema = new Schema({
   email: {

--- a/src/schema/placement.js
+++ b/src/schema/placement.js
@@ -1,7 +1,5 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const Publisher = require('../models/publisher');
-
-const { Schema } = mongoose;
 
 const schema = new Schema({
   name: {

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -1,7 +1,5 @@
-const mongoose = require('mongoose');
+const { Schema } = require('mongoose');
 const validator = require('validator');
-
-const { Schema } = mongoose;
 
 const schema = new Schema({
   name: {

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -1,9 +1,7 @@
+const { Schema } = require('mongoose');
 const bcrypt = require('bcrypt');
-const mongoose = require('mongoose');
 const validator = require('validator');
 const crypto = require('crypto');
-
-const { Schema } = mongoose;
 
 const schema = new Schema({
   email: {

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
-const mongoose = require('./mongoose');
-const redis = require('./redis');
+const mongoose = require('./connections/mongoose');
+const redis = require('./connections/redis');
 const app = require('./app');
 
 /**

--- a/test/connections.js
+++ b/test/connections.js
@@ -1,5 +1,6 @@
-const mongoose = require('../src/mongoose');
-const redis = require('../src/redis');
+const mongoose = require('mongoose');
+const connection = require('../src/connections/mongoose');
+const redis = require('../src/connections/redis');
 const models = require('../src/models');
 
 const index = Model => new Promise((resolve, reject) => {
@@ -16,8 +17,8 @@ const indexes = Promise.all(Object.keys(models).map(name => index(models[name]))
 
 const connect = () => Promise.all([
   new Promise((resolve, reject) => {
-    mongoose.connection.on('connected', resolve);
-    mongoose.connection.on('error', reject);
+    connection.on('connected', resolve);
+    connection.on('error', reject);
   }),
   new Promise((resolve, reject) => {
     redis.on('connect', () => {
@@ -33,7 +34,7 @@ const connect = () => Promise.all([
 
 const disconnect = () => Promise.all([
   new Promise((resolve, reject) => {
-    mongoose.connection.on('disconnected', resolve);
+    connection.on('disconnected', resolve);
     mongoose.disconnect((err) => {
       if (err) reject(err);
     });

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   test:
+    tty: true
     build: ../
     volumes:
       - ../:/app:cached


### PR DESCRIPTION
Adds the ability to watch tests e.g, in a separate terminal.

`test:watch` supports the same parameters as `test`, such as a specific file path or custom reporter. For example:

`yarn run test:watch test/schema/contact.spec.js  --reporter spec` to watch the `contact` schema test and use the `spec` reporter. The default reporter for watching tests is `min`