### PR TITLE
Send custom key/values to tracker and save on events

### DIFF
--- a/src/handlebars.js
+++ b/src/handlebars.js
@@ -13,6 +13,7 @@ const extractFields = (context) => {
   const {
     pid,
     uuid,
+    kv,
     campaign,
     creative,
   } = root || {};
@@ -23,6 +24,7 @@ const extractFields = (context) => {
     pid,
     cid,
     cre,
+    kv,
   };
 };
 
@@ -54,9 +56,7 @@ handlebars.registerHelper('tracked-link', function trackedLink(context) {
 
 handlebars.registerHelper('build-beacon', (context) => {
   const fields = extractFields(context);
-  const keyValues = Object.keys(fields).map(key => ({ key, value: fields[key] }));
-  const fieldsObj = keyValues.filter(o => o.value).map(o => `${o.key}: '${o.value}'`).join(', ');
-  return new handlebars.SafeString(`<script>fortnight('event', 'load', { ${fieldsObj} }, { transport: 'beacon' });</script>`);
+  return new handlebars.SafeString(`<script>fortnight('event', 'load', ${JSON.stringify(fields)}, { transport: 'beacon' });</script>`);
 });
 
 handlebars.registerHelper('build-ua-beacon', (context) => {

--- a/src/repositories/campaign/delivery.js
+++ b/src/repositories/campaign/delivery.js
@@ -249,7 +249,12 @@ module.exports = {
     requestURL,
     event,
   }) {
-    const { cid, pid, uuid } = event;
+    const {
+      cid,
+      pid,
+      uuid,
+      kv,
+    } = event;
     const ad = this.createEmptyAd(cid);
     const trackers = this.createTrackers(requestURL, event);
     const beacon = this.createImgBeacon(trackers);
@@ -258,11 +263,12 @@ module.exports = {
       const vars = Object.assign({}, Object(fallbackVars), {
         pid,
         uuid,
+        kv,
         beacon, // @deprecated Will be removed.
       });
       ad.html = TemplateRepo.render(template.fallback, vars);
     } else {
-      ad.html = TemplateRepo.render(TemplateRepo.getFallbackFallback(true), { pid, uuid });
+      ad.html = TemplateRepo.render(TemplateRepo.getFallbackFallback(true), { pid, uuid, kv });
     }
     return ad;
   },
@@ -330,10 +336,11 @@ module.exports = {
       creative.image.src = await creative.image.getSrc();
     }
 
-    const { uuid, pid } = event;
+    const { uuid, pid, kv } = event;
     const vars = {
       uuid,
       pid,
+      kv,
       beacon, // @deprecated Will be removed.
       href: campaign.url,
       campaign,

--- a/src/repositories/campaign/delivery.js
+++ b/src/repositories/campaign/delivery.js
@@ -68,6 +68,11 @@ module.exports = {
       criteria.$and.push({
         $or: kvsOr,
       });
+    } else {
+      // Ensure that only ads _without_ custom key values are returned.
+      criteria.$and.push({
+        'criteria.kvs.0': { $exists: false },
+      });
     }
     const campaigns = await Campaign.find(criteria);
     return this.selectCampaigns(campaigns, limit);

--- a/src/services/event-handler.js
+++ b/src/services/event-handler.js
@@ -34,7 +34,9 @@ module.exports = {
     let keyValues;
     try {
       keyValues = typeof kv === 'string' ? JSON.parse(kv) : undefined;
-    } catch (e) {}
+    } catch (e) {
+      keyValues = undefined;
+    }
 
     // Validate that the placement, campaign, and creatives exists.
     const placement = await Placement.findOne({ _id: pid }, { _id: 1 });

--- a/src/services/event-handler.js
+++ b/src/services/event-handler.js
@@ -24,11 +24,17 @@ module.exports = {
       uuid,
       cid,
       cre,
+      kv,
     } = fields;
     if (!pid || !mongoId.test(pid)) throw new Error(`The provided pid '${pid}' is invalid.`);
     if (!uuid || !Utils.uuid.is(uuid)) throw new Error(`The provided uuid '${uuid}' is invalid.`);
     if (cid && !mongoId.test(cid)) throw new Error(`The provided cid '${cid}' is invalid.`);
     if (cre && !mongoId.test(cre)) throw new Error(`The provided cre '${cre}' is invalid.`);
+
+    let keyValues;
+    try {
+      keyValues = typeof kv === 'string' ? JSON.parse(kv) : undefined;
+    } catch (e) {}
 
     // Validate that the placement, campaign, and creatives exists.
     const placement = await Placement.findOne({ _id: pid }, { _id: 1 });
@@ -58,6 +64,7 @@ module.exports = {
       ua,
       ref,
       ip,
+      kv: keyValues,
     });
     const event = await doc.save();
     return event;

--- a/test/repositories/campaign/delivery.spec.js
+++ b/test/repositories/campaign/delivery.spec.js
@@ -247,7 +247,7 @@ describe('repositories/campaign/delivery', function() {
       expect(result.length).to.equal(0);
       sinon.assert.calledOnce(Repo.selectCampaigns);
     });
-    it('should return four campaigns when using placement1 and just start date', async function() {
+    it('should return one campaign when using placement1 and just start date', async function() {
       const params = {
         startDate: new Date(),
         placementId: placement1.id,
@@ -256,10 +256,10 @@ describe('repositories/campaign/delivery', function() {
       const promise = Repo.queryCampaigns(params);
       await expect(promise).to.eventually.be.an('array');
       const result = await promise;
-      expect(result.length).to.equal(4);
+      expect(result.length).to.equal(1);
       sinon.assert.calledOnce(Repo.selectCampaigns);
     });
-    it('should return three campaigns when using placement1 and current date is outside end date', async function() {
+    it('should return zero campaigns when using placement1 and current date is outside end date', async function() {
       const params = {
         startDate: moment().add(2, 'year').toDate(),
         placementId: placement1.id,
@@ -268,10 +268,10 @@ describe('repositories/campaign/delivery', function() {
       const promise = Repo.queryCampaigns(params);
       await expect(promise).to.eventually.be.an('array');
       const result = await promise;
-      expect(result.length).to.equal(3);
+      expect(result.length).to.equal(0);
       sinon.assert.calledOnce(Repo.selectCampaigns);
     });
-    it('should return two campaigns when using placement2 and just start date', async function() {
+    it('should return one campaign when using placement2 and just start date', async function() {
       const params = {
         startDate: new Date(),
         placementId: placement2.id,
@@ -280,7 +280,7 @@ describe('repositories/campaign/delivery', function() {
       const promise = Repo.queryCampaigns(params);
       await expect(promise).to.eventually.be.an('array');
       const result = await promise;
-      expect(result.length).to.equal(2);
+      expect(result.length).to.equal(1);
       sinon.assert.calledOnce(Repo.selectCampaigns);
     });
     it('should return three campaigns when using placement1 with start date and sect_id kv', async function() {

--- a/test/repositories/campaign/delivery.spec.js
+++ b/test/repositories/campaign/delivery.spec.js
@@ -391,6 +391,7 @@ describe('repositories/campaign/delivery', function() {
           uuid: '92e998a7-e596-4747-a233-09108938c8d4',
           pid: '5aa03a87be66ee000110c13b',
           cid: '5aabc20d62a17f0001bbcba4',
+          kv: { foo: 'bar' },
         };
 
         const expected = {
@@ -409,7 +410,7 @@ describe('repositories/campaign/delivery', function() {
         sinon.assert.calledOnce(TemplateRepo.render);
         sinon.assert.calledOnce(TemplateRepo.getFallbackFallback);
         sinon.assert.calledWith(TemplateRepo.getFallbackFallback, true);
-        sinon.assert.calledWith(TemplateRepo.render, TemplateRepo.getFallbackFallback(true), { uuid: event.uuid, pid: event.pid });
+        sinon.assert.calledWith(TemplateRepo.render, TemplateRepo.getFallbackFallback(true), { kv: { foo: 'bar' }, uuid: event.uuid, pid: event.pid });
         done();
       });
     });
@@ -448,6 +449,7 @@ describe('repositories/campaign/delivery', function() {
         uuid: '92e998a7-e596-4747-a233-09108938c8d4',
         pid: '5aa03a87be66ee000110c13b',
         cid: '5aabc20d62a17f0001bbcba4',
+        kv: { foo: 'bar' },
       };
 
       const expected = {
@@ -463,10 +465,13 @@ describe('repositories/campaign/delivery', function() {
         requestURL,
         event,
       });
+
+      const fields = JSON.stringify({ uuid: '92e998a7-e596-4747-a233-09108938c8d4', pid: '5aa03a87be66ee000110c13b', kv: { foo: 'bar' } });
+
       expect(result).to.be.an('object');
       ['campaignId, creativeId, fallback'].forEach(k => expect(result[k]).to.equal(expected[k]));
       expect(result.html).to.match(/^<div>Variable here!<\/div>/);
-      expect(result.html).to.match(/<script>fortnight\('event', 'load', { uuid: '92e998a7-e596-4747-a233-09108938c8d4', pid: '5aa03a87be66ee000110c13b' }, { transport: 'beacon' }\);<\/script>/);
+      expect(result.html).to.match(/<script>fortnight\('event', 'load', {"uuid":"92e998a7-e596-4747-a233-09108938c8d4","pid":"5aa03a87be66ee000110c13b","kv":{"foo":"bar"}}, { transport: 'beacon' }\);<\/script>/);
       done();
     });
 
@@ -477,6 +482,7 @@ describe('repositories/campaign/delivery', function() {
         uuid: '92e998a7-e596-4747-a233-09108938c8d4',
         pid: '5aa03a87be66ee000110c13b',
         cid: '5aabc20d62a17f0001bbcba4',
+        kv: { foo: 'bar' },
       };
 
       const expected = {
@@ -495,7 +501,7 @@ describe('repositories/campaign/delivery', function() {
       expect(result).to.be.an('object');
       ['campaignId, creativeId, fallback'].forEach(k => expect(result[k]).to.equal(expected[k]));
       expect(result.html).to.match(/^<div><\/div>/);
-      expect(result.html).to.match(/<script>fortnight\('event', 'load', { uuid: '92e998a7-e596-4747-a233-09108938c8d4', pid: '5aa03a87be66ee000110c13b' }, { transport: 'beacon' }\);<\/script>/);
+      expect(result.html).to.match(/<script>fortnight\('event', 'load', {"uuid":"92e998a7-e596-4747-a233-09108938c8d4","pid":"5aa03a87be66ee000110c13b","kv":{"foo":"bar"}}, { transport: 'beacon' }\);<\/script>/);
       done();
     });
 

--- a/test/repositories/template.spec.js
+++ b/test/repositories/template.spec.js
@@ -290,9 +290,10 @@ describe('repositories/template', function() {
         const data = {
           pid: '5678',
           uuid: 'abcd',
+          kv: { foo: 'bar' },
           campaign: { id: '1234' },
         };
-        const expected = `<script>fortnight('event', 'load', { uuid: 'abcd', pid: '5678', cid: '1234' }, { transport: 'beacon' });</script>`;
+        const expected = `<script>fortnight('event', 'load', {"uuid":"abcd","pid":"5678","cid":"1234","kv":{"foo":"bar"}}, { transport: 'beacon' });</script>`;
         expect(Repo.render(source, data)).to.equal(expected);
         done();
       });
@@ -303,8 +304,9 @@ describe('repositories/template', function() {
           uuid: 'abcd',
           campaign: { id: '1234' },
           creative: { id: '5678' },
+          kv: { foo: 'bar' },
         };
-        const expected = `<script>fortnight('event', 'load', { uuid: 'abcd', pid: '5678', cid: '1234', cre: '5678' }, { transport: 'beacon' });</script>`;
+        const expected = `<script>fortnight('event', 'load', {"uuid":"abcd","pid":"5678","cid":"1234","cre":"5678","kv":{"foo":"bar"}}, { transport: 'beacon' });</script>`;
         expect(Repo.render(source, data)).to.equal(expected);
         done();
       });
@@ -313,14 +315,15 @@ describe('repositories/template', function() {
         const data = {
           pid: '5678',
           uuid: 'abcd',
+          kv: { foo: 'bar' },
         };
-        const expected = `<script>fortnight('event', 'load', { uuid: 'abcd', pid: '5678' }, { transport: 'beacon' });</script>`;
+        const expected = `<script>fortnight('event', 'load', {"uuid":"abcd","pid":"5678","kv":{"foo":"bar"}}, { transport: 'beacon' });</script>`;
         expect(Repo.render(source, data)).to.equal(expected);
         done();
       });
       it('should still render when no attributes are provided.', function(done) {
         const source = '{{build-beacon}}';
-        const expected = `<script>fortnight('event', 'load', {  }, { transport: 'beacon' });</script>`;
+        const expected = `<script>fortnight('event', 'load', {}, { transport: 'beacon' });</script>`;
         expect(Repo.render(source)).to.equal(expected);
         done();
       });


### PR DESCRIPTION
The request custom key/values (`kv`) will now be send to the template beacon and stored within the `analytics-events` collection.