### PR TITLE
Add placements field to Topic type

### DIFF
--- a/src/graph/definitions/topic.graphql
+++ b/src/graph/definitions/topic.graphql
@@ -22,6 +22,7 @@ type Topic {
   id: String!
   name: String!
   publisher: Publisher!
+  placements(pagination: PaginationInput = {}, sort: PlacementSortInput = {}): PlacementConnection!
   updatedAt: Date
   createdAt: Date
 }

--- a/src/graph/resolvers/topic.js
+++ b/src/graph/resolvers/topic.js
@@ -1,6 +1,7 @@
 const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
 const Publisher = require('../../models/publisher');
 const Topic = require('../../models/topic');
+const Placement = require('../../models/placement');
 
 module.exports = {
   /**
@@ -8,6 +9,10 @@ module.exports = {
    */
   Topic: {
     publisher: topic => Publisher.findById(topic.publisherId),
+    placements: (topic, { pagination, sort }) => {
+      const criteria = { topicId: topic.id };
+      return Placement.paginate({ criteria, pagination, sort });
+    },
   },
 
   /**


### PR DESCRIPTION
Placements for a topic can now be displayed using the `placements` field. This field supports placement pagination and sort, similar to the `allPlacements` query.