### PR TITLE
Adds soft delete to remaining models

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,41 @@ In order for a campaign to serve, it must meet the following conditions globally
 4. `criteria.start: { $lte: [now] }`
 5. `$or: [ { criteria.end: { $gt: [now] } }, { crteria.end: { $exists: false } }, { criteria.end: null } ]`
 
+### Deletion Rules
+The following models _cannot_ be soft-deleted when... (note: by "active" we mean "non-deleted" [`deleted: false`])
+
+**Advertiser**
+- An active Story exists with `Story.advertiserId` equal to `Advertiser.id`
+- An active Campaign exists with `Campaign.advertiserId` equal to `Advertiser.id`
+
+**Story**
+- An active Campaign exists with `Campaign.storyId` equal to `Story.id`
+
+**Campaign**
+- No restrictions.
+
+**Publisher**
+- An active Placement exists with `Placement.publisherId` equal to `Publisher.id`
+- An active Topic exists with `Topic.publisherId` equal to `Publisher.id`
+
+**Placement**
+- An active Campaign exists with `Campaign.criteria.placementIds` containing `Placement.id`
+
+**Template**
+- An active Placement exists with `Placement.templateId` equal to `Template.id`
+
+**Topic**
+- An active Placement exists with `Placement.topicId` equal to `Topic.id`
+
+**Contact**
+- No restrictions. _Note:_ When a contact is deleted, it is also removed from the `notify.internal` and `notify.external` fields of `Advertiser` and `Campaign`.
+
+**User**
+- No restrictions. _Note:_ Unlike other models, soft-deleted users will continue to display throughout the interface. This is to ensure that user attribution information is retained.
+
+**Image**
+- Not soft-deleteable.
+
 
 ## Development
 ### Docker Compose

--- a/src/graph/definitions/contact.graphql
+++ b/src/graph/definitions/contact.graphql
@@ -8,6 +8,7 @@ type Query {
 type Mutation {
   createContact(input: CreateContactInput!): Contact!
   updateContact(input: UpdateContactInput!): Contact!
+  deleteContact(input: ModelIdInput!): String!
 }
 
 enum ContactSortField {

--- a/src/graph/definitions/placement.graphql
+++ b/src/graph/definitions/placement.graphql
@@ -8,6 +8,7 @@ type Query {
 type Mutation {
   createPlacement(input: CreatePlacementInput!): Placement!
   updatePlacement(input: UpdatePlacementInput!): Placement!
+  deletePlacement(input: ModelIdInput!): String!
 }
 
 enum PlacementSortField {

--- a/src/graph/definitions/publisher.graphql
+++ b/src/graph/definitions/publisher.graphql
@@ -9,6 +9,7 @@ type Mutation {
   createPublisher(input: CreatePublisherInput!): Publisher!
   updatePublisher(input: UpdatePublisherInput!): Publisher!
   publisherLogo(input: PublisherLogoInput!): Publisher!
+  deletePublisher(input: ModelIdInput!): String!
 }
 
 enum PublisherSortField {

--- a/src/graph/definitions/template.graphql
+++ b/src/graph/definitions/template.graphql
@@ -8,6 +8,7 @@ type Query {
 type Mutation {
   createTemplate(input: CreateTemplateInput!): Template!
   updateTemplate(input: UpdateTemplateInput!): Template!
+  deleteTemplate(input: ModelIdInput!): String!
 }
 
 enum TemplateSortField {

--- a/src/graph/definitions/topic.graphql
+++ b/src/graph/definitions/topic.graphql
@@ -9,6 +9,7 @@ type Query {
 type Mutation {
   createTopic(input: CreateTopicInput!): Topic!
   updateTopic(input: UpdateTopicInput!): Topic!
+  deleteTopic(input: ModelIdInput!): String!
 }
 
 enum TopicSortField {

--- a/src/graph/definitions/user.graphql
+++ b/src/graph/definitions/user.graphql
@@ -34,6 +34,7 @@ type Mutation {
   deleteSession: String
   changeUserPassword(input: ChangeUserPasswordInput!): User
   updateCurrentUserProfile(input: CurrentUserProfileInput!): User
+  deleteUser(input: ModelIdInput!): String!
 }
 
 input ChangeUserPasswordInput {

--- a/src/graph/resolvers/advertiser.js
+++ b/src/graph/resolvers/advertiser.js
@@ -20,8 +20,14 @@ module.exports = {
       return Story.paginate({ pagination, criteria, sort });
     },
     notify: async (advertiser) => {
-      const internal = await Contact.find({ _id: { $in: advertiser.notify.internal } });
-      const external = await Contact.find({ _id: { $in: advertiser.notify.external } });
+      const internal = await Contact.find({
+        _id: { $in: advertiser.notify.internal },
+        deleted: false,
+      });
+      const external = await Contact.find({
+        _id: { $in: advertiser.notify.external },
+        deleted: false,
+      });
       return { internal, external };
     },
     logo: advertiser => Image.findById(advertiser.logoImageId),

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -51,7 +51,7 @@ module.exports = {
     },
     publishers: async (campaign, { pagination, sort }) => {
       const placementIds = campaign.get('criteria.placementIds');
-      const publisherIds = await Placement.distinct('publisherId', { _id: { $in: placementIds } });
+      const publisherIds = await Placement.distinct('publisherId', { _id: { $in: placementIds }, deleted: false });
       const criteria = { _id: { $in: publisherIds } };
       return Publisher.paginate({ pagination, criteria, sort });
     },

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -12,9 +12,12 @@ const contactNotifier = require('../../services/contact-notifier');
 
 const getNotifyDefaults = async (advertiserId, user) => {
   const advertiser = await Advertiser.strictFindById(advertiserId);
+  const internal = await advertiser.get('notify.internal');
+  const external = await advertiser.get('notify.external');
+
   const notify = {
-    internal: await advertiser.get('notify.internal'),
-    external: await advertiser.get('notify.external'),
+    internal: internal.filter(c => !c.deleted),
+    external: external.filter(c => !c.deleted),
   };
   const contact = await Contact.getOrCreateFor(user);
   notify.internal.push(contact.id);
@@ -28,8 +31,14 @@ module.exports = {
   Campaign: {
     advertiser: campaign => Advertiser.findById(campaign.advertiserId),
     notify: async (campaign) => {
-      const internal = await Contact.find({ _id: { $in: campaign.notify.internal } });
-      const external = await Contact.find({ _id: { $in: campaign.notify.external } });
+      const internal = await Contact.find({
+        _id: { $in: campaign.notify.internal },
+        deleted: false,
+      });
+      const external = await Contact.find({
+        _id: { $in: campaign.notify.external },
+        deleted: false,
+      });
       return { internal, external };
     },
     hash: campaign => campaign.pushId,

--- a/src/graph/resolvers/contact.js
+++ b/src/graph/resolvers/contact.js
@@ -66,5 +66,16 @@ module.exports = {
       const { id, payload } = input;
       return Contact.findAndSetUpdate(id, payload);
     },
+
+    /**
+     *
+     */
+    deleteContact: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const contact = await Contact.strictFindActiveById(id);
+      await contact.softDelete();
+      return 'ok';
+    },
   },
 };

--- a/src/graph/resolvers/contact.js
+++ b/src/graph/resolvers/contact.js
@@ -17,7 +17,7 @@ module.exports = {
     contact: (root, { input }, { auth }) => {
       auth.check();
       const { id } = input;
-      return Contact.strictFindById(id);
+      return Contact.strictFindActiveById(id);
     },
 
     /**
@@ -25,7 +25,8 @@ module.exports = {
      */
     allContacts: (root, { pagination, sort }, { auth }) => {
       auth.check();
-      return Contact.paginate({ pagination, sort });
+      const criteria = { deleted: false };
+      return Contact.paginate({ criteria, pagination, sort });
     },
 
     /**
@@ -33,7 +34,8 @@ module.exports = {
      */
     searchContacts: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Contact.search(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Contact.search(phrase, { pagination, filter });
     },
 
     /**
@@ -41,7 +43,8 @@ module.exports = {
      */
     autocompleteContacts: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Contact.autocomplete(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Contact.autocomplete(phrase, { pagination, filter });
     },
   },
 
@@ -61,10 +64,12 @@ module.exports = {
     /**
      *
      */
-    updateContact: (root, { input }, { auth }) => {
+    updateContact: async (root, { input }, { auth }) => {
       auth.check();
       const { id, payload } = input;
-      return Contact.findAndSetUpdate(id, payload);
+      const contact = await Contact.strictFindActiveById(id);
+      contact.set(payload);
+      return contact.save();
     },
 
     /**

--- a/src/graph/resolvers/placement.js
+++ b/src/graph/resolvers/placement.js
@@ -106,5 +106,16 @@ module.exports = {
       });
       return placement.save();
     },
+
+    /**
+     *
+     */
+    deletePlacement: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const placement = await Placement.strictFindActiveById(id);
+      await placement.softDelete();
+      return 'ok';
+    },
   },
 };

--- a/src/graph/resolvers/placement.js
+++ b/src/graph/resolvers/placement.js
@@ -29,7 +29,7 @@ module.exports = {
     placement: (root, { input }, { auth }) => {
       auth.check();
       const { id } = input;
-      return Placement.strictFindById(id);
+      return Placement.strictFindActiveById(id);
     },
 
     /**
@@ -37,7 +37,8 @@ module.exports = {
      */
     allPlacements: (root, { pagination, sort }, { auth }) => {
       auth.check();
-      return Placement.paginate({ pagination, sort });
+      const criteria = { deleted: false };
+      return Placement.paginate({ criteria, pagination, sort });
     },
 
     /**
@@ -45,7 +46,8 @@ module.exports = {
      */
     searchPlacements: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Placement.search(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Placement.search(phrase, { pagination, filter });
     },
 
     /**
@@ -53,7 +55,8 @@ module.exports = {
      */
     autocompletePlacements: async (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Placement.autocomplete(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Placement.autocomplete(phrase, { pagination, filter });
     },
   },
 
@@ -89,7 +92,7 @@ module.exports = {
     updatePlacement: async (root, { input }, { auth }) => {
       auth.check();
       const { id, payload } = input;
-      const placement = await Placement.strictFindById(id);
+      const placement = await Placement.strictFindActiveById(id);
       const {
         name,
         publisherId,

--- a/src/graph/resolvers/publisher.js
+++ b/src/graph/resolvers/publisher.js
@@ -102,5 +102,16 @@ module.exports = {
       publisher.logoImageId = imageId;
       return publisher.save();
     },
+
+    /**
+     *
+     */
+    deletePublisher: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const publisher = await Publisher.strictFindActiveById(id);
+      await publisher.softDelete();
+      return 'ok';
+    },
   },
 };

--- a/src/graph/resolvers/publisher.js
+++ b/src/graph/resolvers/publisher.js
@@ -42,7 +42,7 @@ module.exports = {
     publisher: (root, { input }, { auth }) => {
       auth.check();
       const { id } = input;
-      return Publisher.strictFindById(id);
+      return Publisher.strictFindActiveById(id);
     },
 
     /**
@@ -50,7 +50,8 @@ module.exports = {
      */
     allPublishers: (root, { pagination, sort }, { auth }) => {
       auth.check();
-      return Publisher.paginate({ pagination, sort });
+      const criteria = { deleted: false };
+      return Publisher.paginate({ criteria, pagination, sort });
     },
 
     /**
@@ -58,7 +59,8 @@ module.exports = {
      */
     searchPublishers: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Publisher.search(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Publisher.search(phrase, { pagination, filter });
     },
 
     /**
@@ -66,7 +68,8 @@ module.exports = {
      */
     autocompletePublishers: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Publisher.autocomplete(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Publisher.autocomplete(phrase, { pagination, filter });
     },
   },
 

--- a/src/graph/resolvers/publisher.js
+++ b/src/graph/resolvers/publisher.js
@@ -12,17 +12,17 @@ module.exports = {
   Publisher: {
     logo: publisher => Image.findById(publisher.logoImageId),
     topics: (publisher, { pagination, sort }) => {
-      const criteria = { publisherId: publisher.id };
+      const criteria = { publisherId: publisher.id, deleted: false };
       return Topic.paginate({ criteria, pagination, sort });
     },
     placements: (publisher, { pagination, sort }) => {
-      const criteria = { publisherId: publisher.id };
+      const criteria = { publisherId: publisher.id, deleted: false };
       return Placement.paginate({ criteria, pagination, sort });
     },
     campaigns: async (publisher, { pagination, sort }) => {
       const placements = await Placement.find({ publisherId: publisher.id }, { _id: 1 });
       const placementIds = placements.map(placement => placement.id);
-      const criteria = { 'criteria.placementIds': { $in: placementIds } };
+      const criteria = { 'criteria.placementIds': { $in: placementIds }, deleted: false };
       return Campaign.paginate({ criteria, pagination, sort });
     },
   },

--- a/src/graph/resolvers/template.js
+++ b/src/graph/resolvers/template.js
@@ -66,5 +66,16 @@ module.exports = {
       const { id, payload } = input;
       return Template.findAndSetUpdate(id, payload);
     },
+
+    /**
+     *
+     */
+    deleteTemplate: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const template = await Template.strictFindActiveById(id);
+      await template.softDelete();
+      return 'ok';
+    },
   },
 };

--- a/src/graph/resolvers/template.js
+++ b/src/graph/resolvers/template.js
@@ -17,7 +17,7 @@ module.exports = {
     template: (root, { input }, { auth }) => {
       auth.check();
       const { id } = input;
-      return Template.strictFindById(id);
+      return Template.strictFindActiveById(id);
     },
 
     /**
@@ -25,7 +25,8 @@ module.exports = {
      */
     allTemplates: (root, { pagination, sort }, { auth }) => {
       auth.check();
-      return Template.paginate({ pagination, sort });
+      const criteria = { deleted: false };
+      return Template.paginate({ criteria, pagination, sort });
     },
 
     /**
@@ -33,7 +34,8 @@ module.exports = {
      */
     searchTemplates: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Template.search(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Template.search(phrase, { pagination, filter });
     },
 
     /**
@@ -41,7 +43,8 @@ module.exports = {
      */
     autocompleteTemplates: (root, { pagination, phrase }, { auth }) => {
       auth.check();
-      return Template.autocomplete(phrase, { pagination });
+      const filter = { term: { deleted: false } };
+      return Template.autocomplete(phrase, { pagination, filter });
     },
   },
 
@@ -61,10 +64,12 @@ module.exports = {
     /**
      *
      */
-    updateTemplate: (root, { input }, { auth }) => {
+    updateTemplate: async (root, { input }, { auth }) => {
       auth.check();
       const { id, payload } = input;
-      return Template.findAndSetUpdate(id, payload);
+      const template = await Template.strictFindActiveById(id);
+      template.set(payload);
+      return template.save();
     },
 
     /**

--- a/src/graph/resolvers/topic.js
+++ b/src/graph/resolvers/topic.js
@@ -85,5 +85,16 @@ module.exports = {
       const { id, payload } = input;
       return Topic.findAndSetUpdate(id, payload);
     },
+
+    /**
+     *
+     */
+    deleteTopic: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const template = await Topic.strictFindActiveById(id);
+      await template.softDelete();
+      return 'ok';
+    },
   },
 };

--- a/src/graph/resolvers/topic.js
+++ b/src/graph/resolvers/topic.js
@@ -89,6 +89,7 @@ module.exports = {
       const { id, payload } = input;
       const topic = await Topic.strictFindActiveById(id);
       topic.set(payload);
+      return topic.save();
     },
 
     /**

--- a/src/graph/resolvers/topic.js
+++ b/src/graph/resolvers/topic.js
@@ -10,7 +10,7 @@ module.exports = {
   Topic: {
     publisher: topic => Publisher.findById(topic.publisherId),
     placements: (topic, { pagination, sort }) => {
-      const criteria = { topicId: topic.id };
+      const criteria = { topicId: topic.id, deleted: false };
       return Placement.paginate({ criteria, pagination, sort });
     },
   },

--- a/src/graph/resolvers/user.js
+++ b/src/graph/resolvers/user.js
@@ -66,7 +66,7 @@ module.exports = {
       const { id, value, confirm } = input;
       if (user.id.valueOf() === id || auth.isAdmin()) {
         validatePassword(value, confirm);
-        const record = await User.findOne({ _id: id });
+        const record = await User.findActiveById(id);
         if (!record) throw new Error(`No user record found for ID ${id}.`);
         record.password = value;
         return record.save();

--- a/src/graph/resolvers/user.js
+++ b/src/graph/resolvers/user.js
@@ -27,6 +27,9 @@ module.exports = {
       return { user, session };
     },
   },
+  /**
+   *
+   */
   Mutation: {
     /**
      *
@@ -80,6 +83,16 @@ module.exports = {
       const { user } = auth;
       user.set({ givenName, familyName });
       return user.save();
+    },
+
+    /**
+     *
+     */
+    deleteUser: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const user = await User.strictFindById(id);
+      return user.softDelete();
     },
   },
 };

--- a/src/plugins/notify.js
+++ b/src/plugins/notify.js
@@ -14,11 +14,54 @@ const ContactReference = {
   },
 };
 
+const getIds = (doc, fieldName) => {
+  const value = doc.get(fieldName);
+  return Array.isArray(value) ? value : [];
+};
+
 module.exports = function notifyPlugin(schema) {
   schema.add({
     notify: {
       internal: [ContactReference],
       external: [ContactReference],
     },
+  });
+
+  schema.method('addContactId', function addContactId(type, contactId) {
+    const fieldName = `notify.${type}`;
+    const ids = getIds(this, fieldName);
+
+    const current = ids.map(id => `${id}`);
+    current.push(`${contactId}`);
+    this.set(fieldName, [...new Set(current)]);
+  });
+
+  schema.method('removeContactId', function removeContactId(type, contactId) {
+    const fieldName = `notify.${type}`;
+    const ids = getIds(this, fieldName);
+
+    const filtered = ids.filter(id => `${id}` !== `${contactId}`);
+    this.set(fieldName, filtered);
+  });
+
+  schema.method('addInternalContactId', function addInternalContactId(contactId) {
+    this.addContactId('internal', contactId);
+  });
+
+  schema.method('addExternalContactId', function addExternalContactId(contactId) {
+    this.addContactId('external', contactId);
+  });
+
+  schema.method('removeInternalContactId', function removeInternalContactId(contactId) {
+    this.removeContactId('internal', contactId);
+  });
+
+  schema.method('removeExternalContactId', function removeExternalContactId(contactId) {
+    this.removeContactId('external', contactId);
+  });
+
+  schema.method('removeContactIdAll', function removeContactIdAll(contactId) {
+    this.removeContactId('internal', contactId);
+    this.removeContactId('external', contactId);
   });
 };

--- a/src/repositories/user.js
+++ b/src/repositories/user.js
@@ -17,7 +17,7 @@ module.exports = {
   findByEmail(email) {
     const value = this.normalizeEmail(email);
     if (!value) return Promise.reject(new Error('Unable to find user: no email address was provided.'));
-    return User.findOne({ email: value });
+    return User.findOne({ email: value, deleted: false });
   },
 
   normalizeEmail(email) {
@@ -32,7 +32,7 @@ module.exports = {
    */
   findById(id) {
     if (!id) return Promise.reject(new Error('Unable to find user: no ID was provided.'));
-    return User.findOne({ _id: id });
+    return User.findOne({ _id: id, deleted: false });
   },
 
   removeByEmail(email) {

--- a/src/schema/advertiser.js
+++ b/src/schema/advertiser.js
@@ -39,9 +39,9 @@ schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
 
   const stories = await connection.model('story').countActive({ advertiserId: this.id });
-  if (stories) throw new Error('You cannot delete an advertiser with related stories.');
+  if (stories) throw new Error('You cannot delete an advertiser that has related stories.');
   const campaigns = await connection.model('campaign').countActive({ advertiserId: this.id });
-  if (campaigns) throw new Error('You cannot delete an advertiser with related campaigns.');
+  if (campaigns) throw new Error('You cannot delete an advertiser that has related campaigns.');
 });
 
 schema.pre('save', async function updateCampaigns() {

--- a/src/schema/contact.js
+++ b/src/schema/contact.js
@@ -2,6 +2,7 @@ const { Schema } = require('mongoose');
 const validator = require('validator');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
 const {
+  deleteablePlugin,
   paginablePlugin,
   repositoryPlugin,
   searchablePlugin,
@@ -58,6 +59,10 @@ const schema = new Schema({
 setEntityFields(schema, 'name');
 applyElasticPlugin(schema, 'contacts');
 
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
 schema.plugin(repositoryPlugin);
 schema.plugin(paginablePlugin);
 schema.plugin(searchablePlugin, {

--- a/src/schema/contact.js
+++ b/src/schema/contact.js
@@ -13,7 +13,6 @@ const schema = new Schema({
     type: String,
     required: true,
     trim: true,
-    unique: true,
     lowercase: true,
     validate: [
       {
@@ -91,6 +90,7 @@ schema.statics.getOrCreateFor = async function getOrCreateFor({ email, givenName
   return this.create({ givenName, familyName, email });
 };
 
+schema.index({ email: 1, deleted: 1 }, { unique: true });
 schema.index({ name: 1, _id: 1 }, { unique: true });
 schema.index({ name: -1, _id: -1 }, { unique: true });
 schema.index({ updatedAt: 1, _id: 1 }, { unique: true });

--- a/src/schema/contact.js
+++ b/src/schema/contact.js
@@ -80,7 +80,7 @@ schema.plugin(searchablePlugin, {
   },
 });
 
-schema.pre('save', function setName(next) {
+schema.pre('validate', function setName(next) {
   this.name = `${this.givenName} ${this.familyName}`;
   next();
 });

--- a/src/schema/placement.js
+++ b/src/schema/placement.js
@@ -58,6 +58,13 @@ schema.plugin(paginablePlugin);
 schema.plugin(reservePctPlugin);
 schema.plugin(searchablePlugin, { fieldNames: ['name', 'publisherName', 'topicName', 'templateName'] });
 
+schema.pre('save', async function checkDelete() {
+  if (!this.isModified('deleted') || !this.deleted) return;
+
+  const campaigns = await connection.model('campaigns').countActive({ 'criteria.placementIds': this.id });
+  if (campaigns) throw new Error('You cannot delete a placement that has related campaigns.');
+});
+
 schema.pre('save', async function setPublisherName() {
   if (this.isModified('publisherId') || !this.publisherName) {
     const publisher = await connection.model('publisher').findOne({ _id: this.publisherId }, { name: 1 });

--- a/src/schema/placement.js
+++ b/src/schema/placement.js
@@ -61,7 +61,7 @@ schema.plugin(searchablePlugin, { fieldNames: ['name', 'publisherName', 'topicNa
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
 
-  const campaigns = await connection.model('campaigns').countActive({ 'criteria.placementIds': this.id });
+  const campaigns = await connection.model('campaign').countActive({ 'criteria.placementIds': this.id });
   if (campaigns) throw new Error('You cannot delete a placement that has related campaigns.');
 });
 

--- a/src/schema/placement.js
+++ b/src/schema/placement.js
@@ -2,6 +2,7 @@ const { Schema } = require('mongoose');
 const connection = require('../connections/mongoose/instance');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
 const {
+  deleteablePlugin,
   paginablePlugin,
   referencePlugin,
   repositoryPlugin,
@@ -47,6 +48,10 @@ schema.plugin(referencePlugin, {
   name: 'topicId',
   connection,
   modelName: 'topic',
+});
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
 });
 schema.plugin(repositoryPlugin);
 schema.plugin(paginablePlugin);

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -3,6 +3,7 @@ const { isFQDN } = require('validator');
 const connection = require('../connections/mongoose/instance');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
 const {
+  deleteablePlugin,
   imagePlugin,
   paginablePlugin,
   repositoryPlugin,
@@ -32,6 +33,10 @@ const schema = new Schema({
 setEntityFields(schema, 'name');
 applyElasticPlugin(schema, 'publishers');
 
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
 schema.plugin(imagePlugin, { fieldName: 'logoImageId' });
 schema.plugin(repositoryPlugin);
 schema.plugin(paginablePlugin);

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -42,6 +42,15 @@ schema.plugin(repositoryPlugin);
 schema.plugin(paginablePlugin);
 schema.plugin(searchablePlugin, { fieldNames: ['name'] });
 
+schema.pre('save', async function checkDelete() {
+  if (!this.isModified('deleted') || !this.deleted) return;
+
+  const placements = await connection.model('placement').countActive({ publisherId: this.id });
+  if (placements) throw new Error('You cannot delete a publisher that has related placements.');
+  const topics = await connection.model('topic').countActive({ publisherId: this.id });
+  if (topics) throw new Error('You cannot delete a publisher that has related topics.');
+});
+
 schema.pre('save', async function updatePlacements() {
   if (this.isModified('name')) {
     // This isn't as efficient as calling `updateMany`, but the ElasticSearch

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -80,7 +80,7 @@ schema.virtual('status').get(function getStatus() {
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
   const count = await connection.model('campaign').countActive({ storyId: this.id });
-  if (count) throw new Error('You cannot delete a story with related campaigns');
+  if (count) throw new Error('You cannot delete a story that has related campaigns.');
 });
 
 schema.pre('save', async function setAdvertiserName() {

--- a/src/schema/template.js
+++ b/src/schema/template.js
@@ -135,7 +135,7 @@ schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
 
   const placements = await connection.model('placement').countActive({ templateId: this.id });
-  if (placements) throw new Error('You cannot delete a template with related placements.');
+  if (placements) throw new Error('You cannot delete a template that has related placements.');
 });
 
 /**

--- a/src/schema/template.js
+++ b/src/schema/template.js
@@ -131,6 +131,13 @@ schema.pre('save', async function updatePlacements() {
   }
 });
 
+schema.pre('save', async function checkDelete() {
+  if (!this.isModified('deleted') || !this.deleted) return;
+
+  const placements = await connection.model('placement').countActive({ templateId: this.id });
+  if (placements) throw new Error('You cannot delete a template with related placements.');
+});
+
 /**
  * Renders/compiles a template from the provided source with the
  * provided data hash.

--- a/src/schema/template.js
+++ b/src/schema/template.js
@@ -3,6 +3,7 @@ const handlebars = require('../handlebars');
 const connection = require('../connections/mongoose/instance');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
 const {
+  deleteablePlugin,
   paginablePlugin,
   repositoryPlugin,
   searchablePlugin,
@@ -108,6 +109,10 @@ const schema = new Schema({
 setEntityFields(schema, 'name');
 applyElasticPlugin(schema, 'templates');
 
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
 schema.plugin(repositoryPlugin);
 schema.plugin(paginablePlugin);
 schema.plugin(searchablePlugin, { fieldNames: ['name'] });

--- a/src/schema/topic.js
+++ b/src/schema/topic.js
@@ -45,7 +45,7 @@ schema.plugin(searchablePlugin, { fieldNames: ['name', 'publisherName'] });
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
 
-  const placements = await connection.model('placement').countActive({ templateId: this.id });
+  const placements = await connection.model('placement').countActive({ topicId: this.id });
   if (placements) throw new Error('You cannot delete a topic that has related placements.');
 });
 

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -2,13 +2,20 @@ const bcrypt = require('bcrypt');
 const { Schema } = require('mongoose');
 const validator = require('validator');
 const crypto = require('crypto');
+const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
+const {
+  deleteablePlugin,
+  paginablePlugin,
+  repositoryPlugin,
+  searchablePlugin,
+} = require('../plugins');
+
 
 const schema = new Schema({
   email: {
     type: String,
     required: true,
     trim: true,
-    unique: true,
     lowercase: true,
     validate: [
       {
@@ -25,6 +32,11 @@ const schema = new Schema({
     trim: true,
   },
   familyName: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  name: {
     type: String,
     required: true,
     trim: true,
@@ -71,14 +83,44 @@ const schema = new Schema({
   timestamps: true,
 });
 
+setEntityFields(schema, 'name');
+applyElasticPlugin(schema, 'users');
+
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
+schema.plugin(repositoryPlugin);
+schema.plugin(paginablePlugin);
+schema.plugin(searchablePlugin, {
+  fieldNames: ['name'],
+  beforeSearch: (query, phrase) => {
+    const { should } = query.bool;
+    should.push({ match: { email: { query: phrase, boost: 5 } } });
+    should.push({ match: { 'email.edge': { query: phrase, operator: 'and', boost: 2 } } });
+    should.push({ match: { 'email.edge': { query: phrase, boost: 1 } } });
+  },
+  beforeAutocomplete: (query, phrase) => {
+    const { should } = query.bool;
+    should.push({ match: { 'email.edge': { query: phrase, operator: 'and', boost: 2 } } });
+    should.push({ match: { 'email.edge': { query: phrase, boost: 1 } } });
+  },
+});
+
 /**
  * Indexes
  */
 schema.index({ email: 1, isEmailVerified: 1 });
+schema.index({ email: 1, deleted: 1 }, { unique: true });
 
 /**
  * Hooks.
  */
+schema.pre('save', function setName(next) {
+  this.name = `${this.givenName} ${this.familyName}`;
+  next();
+});
+
 schema.pre('save', function setPassword(next) {
   if (!this.isModified('password')) {
     next();
@@ -89,6 +131,7 @@ schema.pre('save', function setPassword(next) {
     }).catch(next);
   }
 });
+
 schema.pre('save', function setPhotoURL(next) {
   if (!this.photoURL) {
     const hash = crypto.createHash('md5').update(this.email).digest('hex');

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -116,7 +116,7 @@ schema.index({ email: 1, deleted: 1 }, { unique: true });
 /**
  * Hooks.
  */
-schema.pre('save', function setName(next) {
+schema.pre('validate', function setName(next) {
   this.name = `${this.givenName} ${this.familyName}`;
   next();
 });

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -25,6 +25,19 @@ const schema = new Schema({
         message: 'Invalid email address {VALUE}',
       },
     ],
+    es_indexed: true,
+    es_type: 'text',
+    es_analyzer: 'email_address',
+    es_fields: {
+      raw: {
+        type: 'keyword',
+      },
+      edge: {
+        type: 'text',
+        analyzer: 'email_address_starts_with',
+        search_analyzer: 'email_address',
+      },
+    },
   },
   givenName: {
     type: String,

--- a/test/elastic/models.spec.js
+++ b/test/elastic/models.spec.js
@@ -11,6 +11,7 @@ describe('elastic/models', function() {
       'template',
       'topic',
       'story',
+      'user',
     ].sort();
     const names = models.map(Model => Model.modelName);
     expect(names.sort()).to.deep.equal(expected);


### PR DESCRIPTION
From the new README

### Deletion Rules
The following models _cannot_ be soft-deleted when... (note: by "active" we mean "non-deleted" [`deleted: false`])

**Advertiser**
- An active Story exists with `Story.advertiserId` equal to `Advertiser.id`
- An active Campaign exists with `Campaign.advertiserId` equal to `Advertiser.id`

**Story**
- An active Campaign exists with `Campaign.storyId` equal to `Story.id`

**Campaign**
- No restrictions.

**Publisher**
- An active Placement exists with `Placement.publisherId` equal to `Publisher.id`
- An active Topic exists with `Topic.publisherId` equal to `Publisher.id`

**Placement**
- An active Campaign exists with `Campaign.criteria.placementIds` containing `Placement.id`

**Template**
- An active Placement exists with `Placement.templateId` equal to `Template.id`

**Topic**
- An active Placement exists with `Placement.topicId` equal to `Topic.id`

**Contact**
- No restrictions. _Note:_ When a contact is deleted, it is also removed from the `notify.internal` and `notify.external` fields of `Advertiser` and `Campaign`.

**User**
- No restrictions. _Note:_ Unlike other models, soft-deleted users will continue to display throughout the interface. This is to ensure that user attribution information is retained.

**Image**
- Not soft-deleteable.
