### PR TITLE
Add campaign external contact mutations

### DIFF
--- a/src/graph/definitions/campaign.graphql
+++ b/src/graph/definitions/campaign.graphql
@@ -31,6 +31,7 @@ type Mutation {
   campaignContacts(input: SetContactsInput!): Campaign!
 
   campaignExternalContact(input: CampaignExternalContactInput!): Campaign!
+  removeCampaignExternalContact(input: RemoveCampaignExternalContactInput!): Campaign!
 }
 
 enum CampaignSortField {
@@ -107,6 +108,11 @@ type CampaignConnection {
 type CampaignEdge {
   node: Campaign!
   cursor: Cursor!
+}
+
+input RemoveCampaignExternalContactInput {
+  campaignId: String!
+  contactId: String!
 }
 
 input CampaignExternalContactInput {

--- a/src/graph/definitions/campaign.graphql
+++ b/src/graph/definitions/campaign.graphql
@@ -111,7 +111,6 @@ type CampaignEdge {
 
 input CampaignExternalContactInput {
   campaignId: String!
-  contactId: String # A null id here signifies a new assignment
   payload: CampaignExternalContactPayloadInput!
 }
 

--- a/src/graph/definitions/campaign.graphql
+++ b/src/graph/definitions/campaign.graphql
@@ -29,6 +29,8 @@ type Mutation {
   campaignCreativeImage(input: CampaignCreativeImageInput!): CampaignCreative!
 
   campaignContacts(input: SetContactsInput!): Campaign!
+
+  campaignExternalContact(input: CampaignExternalContactInput!): Campaign!
 }
 
 enum CampaignSortField {
@@ -105,6 +107,18 @@ type CampaignConnection {
 type CampaignEdge {
   node: Campaign!
   cursor: Cursor!
+}
+
+input CampaignExternalContactInput {
+  campaignId: String!
+  contactId: String # A null id here signifies a new assignment
+  payload: CampaignExternalContactPayloadInput!
+}
+
+input CampaignExternalContactPayloadInput {
+  email: String!
+  givenName: String!
+  familyName: String!
 }
 
 input AssignCampaignValueInput {

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -340,13 +340,12 @@ module.exports = {
     },
 
     campaignExternalContact: async (root, { input }, { auth }) => {
-      const { campaignId, contactId, payload } = input;
+      const { campaignId, payload } = input;
       const { email, givenName, familyName } = payload;
       auth.checkCampaignAccess(campaignId);
       const campaign = await Campaign.strictFindActiveById(campaignId);
 
-      const criteria = contactId ? { _id: contactId } : { email, deleted: false };
-      const contact = await Contact.findOneAndUpdate(criteria, {
+      const contact = await Contact.findOneAndUpdate({ email, deleted: false }, {
         $set: {
           familyName,
           givenName,

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -365,5 +365,17 @@ module.exports = {
       campaign.get('notify.external').push(contact.id);
       return campaign.save();
     },
+
+    removeCampaignExternalContact: async (root, { input }, { auth }) => {
+      const { campaignId, contactId } = input;
+      auth.checkCampaignAccess(campaignId);
+      const campaign = await Campaign.strictFindActiveById(campaignId);
+
+      campaign.removeExternalContactId(contactId);
+      if (auth.user) {
+        campaign.setUserContext(auth.user);
+      }
+      return campaign.save();
+    },
   },
 };


### PR DESCRIPTION
Adds `campaignExternalContact` for assigning and `removeCampaignExternalContact` for removing external contacts for a campaign.