### PR TITLE
Publisher/branding context + canonical + sitemap

### DIFF
--- a/src/fixtures/generators/advertiser.js
+++ b/src/fixtures/generators/advertiser.js
@@ -15,6 +15,7 @@ module.exports = async ({
     updatedAt: now,
     createdById: await createdById(),
     updatedById: await updatedById(),
+    website: faker.internet.url(),
     notify: {
       internal: internalContactIds,
       external: externalContactIds,

--- a/src/fixtures/generators/publisher.js
+++ b/src/fixtures/generators/publisher.js
@@ -7,6 +7,7 @@ module.exports = async ({ createdById, updatedById }) => {
     logo: faker.image.imageUrl(100, 100, undefined, undefined, true),
     createdAt: now,
     updatedAt: now,
+    website: faker.internet.url(),
     createdById: await createdById(),
     updatedById: await updatedById(),
   };

--- a/src/fixtures/generators/story.js
+++ b/src/fixtures/generators/story.js
@@ -2,6 +2,7 @@ const faker = require('faker');
 
 module.exports = async ({
   advertiserId,
+  publisherId,
   primaryImageId,
   imageIds,
   createdById,
@@ -13,6 +14,7 @@ module.exports = async ({
     teaser: faker.lorem.words(10),
     body: faker.lorem.words(10),
     advertiserId: await advertiserId(),
+    publisherId: await publisherId(),
     primaryImageId: await primaryImageId(),
     imageIds: await imageIds(),
     createdAt: now,

--- a/src/fixtures/seed.js
+++ b/src/fixtures/seed.js
@@ -114,9 +114,11 @@ module.exports = {
     const { Story } = models;
     const user = await this.users(1);
     const advertiser = await this.advertisers(1);
+    const publisher = await this.publishers(1);
     const images = await this.images(3);
     const params = {
       advertiserId: () => advertiser.id,
+      publisherId: () => publisher.id,
       primaryImageId: () => images[0].id,
       imageIds: () => images.map(image => image.id),
       updatedById: () => user.id,

--- a/src/graph/definitions/account.graphql
+++ b/src/graph/definitions/account.graphql
@@ -11,6 +11,7 @@ type Account {
   key: String!
   name: String!
   uri: String!
+  storyUri: String!
   settings: AccountSettings!
   createdAt: Date
   updatedAt: Date

--- a/src/graph/definitions/advertiser.graphql
+++ b/src/graph/definitions/advertiser.graphql
@@ -28,6 +28,7 @@ type Advertiser implements UserAttribution & Timestampable {
   hash: String!
   name: String!
   logo: Image
+  website: String
   deleted: Boolean!
   createdAt: Date
   updatedAt: Date
@@ -69,6 +70,7 @@ input AdvertiserSortInput {
 
 input AdvertiserPayloadInput {
   name: String!
+  website: String
   notify: AdvertiserContactsInput
 }
 

--- a/src/graph/definitions/campaign.graphql
+++ b/src/graph/definitions/campaign.graphql
@@ -161,6 +161,7 @@ input CreateExternalUrlCampaignInput {
 input CreateNewStoryCampaignInput {
   name: String!
   advertiserId: String!
+  publisherId: String!
 }
 
 input CreateExistingStoryCampaignInput {

--- a/src/graph/definitions/publisher.graphql
+++ b/src/graph/definitions/publisher.graphql
@@ -22,6 +22,7 @@ type Publisher implements UserAttribution & Timestampable {
   id: String!
   name: String!
   domainName: String
+  website: String!
   logo: Image
   topics(pagination: PaginationInput = {}, sort: TopicSortInput = {}): TopicConnection!
   placements(pagination: PaginationInput = {}, sort: PlacementSortInput = {}): PlacementConnection!
@@ -71,6 +72,7 @@ input PublisherSortInput {
 
 input PublisherPayloadInput {
   name: String!
+  website: String!
 }
 
 input CreatePublisherInput {

--- a/src/graph/definitions/story.graphql
+++ b/src/graph/definitions/story.graphql
@@ -44,6 +44,7 @@ type Story implements UserAttribution & Timestampable {
   title: String!
   slug: String!
   advertiser: Advertiser!
+  publisher: Publisher!
   teaser: String
   body: String
   path: String!
@@ -105,6 +106,7 @@ input StoryPayloadInput {
   teaser: String
   body: String
   advertiserId: String!
+  publisherId: String!
   publishedAt: Date
 }
 

--- a/src/graph/definitions/story.graphql
+++ b/src/graph/definitions/story.graphql
@@ -45,7 +45,7 @@ type Story implements UserAttribution & Timestampable {
   title: String!
   slug: String!
   advertiser: Advertiser!
-  publisher: Publisher!
+  publisher(contextId: String): Publisher! #optionally can override the primary publisher.
   teaser: String
   body: String
   path: String!

--- a/src/graph/definitions/story.graphql
+++ b/src/graph/definitions/story.graphql
@@ -55,6 +55,7 @@ type Story implements UserAttribution & Timestampable {
   primaryImage: Image
   images: [Image]
   previewUrl: String!
+  url: String!
   campaigns(pagination: PaginationInput = {}, sort: CampaignSortInput = {}): CampaignConnection!
   createdAt: Date!
   updatedAt: Date!

--- a/src/graph/definitions/story.graphql
+++ b/src/graph/definitions/story.graphql
@@ -70,6 +70,13 @@ type StorySitemapItem {
   lastmod: String
   changefreq: String
   priority: Float
+  image: StorySitemapImage
+}
+
+type StorySitemapImage {
+  id: String!
+  loc: String!
+  caption: String
 }
 
 type StoryConnection {

--- a/src/graph/definitions/story.graphql
+++ b/src/graph/definitions/story.graphql
@@ -6,6 +6,7 @@ type Query {
   story(input: ModelIdInput!): Story!
   publishedStory(input: PublishedStoryInput!): Story!
   storyHash(input: StoryHashInput!): Story!
+  storySitemap: [StorySitemapItem]!
 }
 
 type Mutation {
@@ -61,6 +62,14 @@ type Story implements UserAttribution & Timestampable {
   updatedAt: Date!
   createdBy: User!
   updatedBy: User!
+}
+
+type StorySitemapItem {
+  id: String!
+  loc: String!
+  lastmod: String
+  changefreq: String
+  priority: Float
 }
 
 type StoryConnection {

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -313,12 +313,13 @@ module.exports = {
      */
     createNewStoryCampaign: async (root, { input }, { auth }) => {
       auth.check();
-      const { name, advertiserId } = input;
+      const { name, advertiserId, publisherId } = input;
       const notify = await getNotifyDefaults(advertiserId, auth.user);
 
       const story = new Story({
         title: 'Placeholder Story',
         advertiserId,
+        publisherId,
         placeholder: true,
       });
       story.setUserContext(auth.user);

--- a/src/graph/resolvers/story.js
+++ b/src/graph/resolvers/story.js
@@ -2,6 +2,7 @@ const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
 const userAttributionFields = require('./user-attribution');
 const Advertiser = require('../../models/advertiser');
 const Campaign = require('../../models/campaign');
+const Publisher = require('../../models/publisher');
 const Story = require('../../models/story');
 const Image = require('../../models/image');
 const accountService = require('../../services/account');
@@ -23,6 +24,7 @@ module.exports = {
     // @todo Determine if this should run a strict/active find.
     // Ultimately, deleting an advertiser should delete it's stories?
     advertiser: story => Advertiser.findById(story.advertiserId),
+    publisher: story => Publisher.findById(story.publisherId),
     primaryImage: story => Image.findById(story.primaryImageId),
     images: story => Image.find({ _id: { $in: story.imageIds } }),
     campaigns: (story, { pagination, sort }) => {
@@ -128,12 +130,14 @@ module.exports = {
       const {
         title,
         advertiserId,
+        publisherId,
         publishedAt,
       } = payload;
 
       const story = new Story({
         title,
         advertiserId,
+        publisherId,
         publishedAt,
       });
       story.setUserContext(auth.user);
@@ -162,6 +166,7 @@ module.exports = {
         teaser,
         body,
         advertiserId,
+        publisherId,
         publishedAt,
       } = payload;
 
@@ -172,6 +177,7 @@ module.exports = {
         teaser,
         body,
         advertiserId,
+        publisherId,
         publishedAt,
       });
       return story.save();

--- a/src/graph/resolvers/story.js
+++ b/src/graph/resolvers/story.js
@@ -33,13 +33,11 @@ module.exports = {
     },
     previewUrl: async (story) => {
       const account = await accountService.retrieve();
-      return `${storyUrl(account.storyUri, story.id)}/?preview=true`;
+      const path = await story.getPath();
+      return `${storyUrl(account.storyUri, path)}/?preview=true`;
     },
     hash: story => story.pushId,
-    path: async (story) => {
-      const advertiser = await Advertiser.findById(story.advertiserId);
-      return `${advertiser.slug}/${story.slug}/${story.id}`;
-    },
+    path: story => story.getPath(),
     ...userAttributionFields,
   },
 

--- a/src/graph/resolvers/story.js
+++ b/src/graph/resolvers/story.js
@@ -23,7 +23,10 @@ module.exports = {
     // @todo Determine if this should run a strict/active find.
     // Ultimately, deleting an advertiser should delete it's stories?
     advertiser: story => Advertiser.findById(story.advertiserId),
-    publisher: story => Publisher.findById(story.publisherId),
+    publisher: (story, { contextId }) => {
+      const publisherId = contextId || story.publisherId;
+      return Publisher.findById(publisherId);
+    },
     primaryImage: story => Image.findById(story.primaryImageId),
     images: story => Image.find({ _id: { $in: story.imageIds } }),
     campaigns: (story, { pagination, sort }) => {

--- a/src/graph/resolvers/story.js
+++ b/src/graph/resolvers/story.js
@@ -30,7 +30,7 @@ module.exports = {
       const criteria = { storyId: story.id, deleted: false };
       return Campaign.paginate({ pagination, criteria, sort });
     },
-    previewUrl: story => story.getUrl(true),
+    previewUrl: story => story.getUrl({ preview: true }),
     url: story => story.getUrl(),
     hash: story => story.pushId,
     path: story => story.getPath(),

--- a/src/graph/resolvers/story.js
+++ b/src/graph/resolvers/story.js
@@ -54,6 +54,15 @@ module.exports = {
     lastmod: ({ updatedAt }) => (updatedAt ? moment(updatedAt).toISOString() : null),
     changefreq: () => 'monthly',
     priority: () => 0.5,
+    image: ({ primaryImageId }) => {
+      if (!primaryImageId) return null;
+      return Image.findById(primaryImageId);
+    },
+  },
+
+  StorySitemapImage: {
+    loc: image => image.getSrc(),
+    caption: () => null,
   },
 
   /**

--- a/src/graph/resolvers/story.js
+++ b/src/graph/resolvers/story.js
@@ -5,8 +5,6 @@ const Campaign = require('../../models/campaign');
 const Publisher = require('../../models/publisher');
 const Story = require('../../models/story');
 const Image = require('../../models/image');
-const accountService = require('../../services/account');
-const storyUrl = require('../../utils/story-url');
 
 const storySearchFilter = [
   {
@@ -31,11 +29,8 @@ module.exports = {
       const criteria = { storyId: story.id, deleted: false };
       return Campaign.paginate({ pagination, criteria, sort });
     },
-    previewUrl: async (story) => {
-      const account = await accountService.retrieve();
-      const path = await story.getPath();
-      return `${storyUrl(account.storyUri, path)}/?preview=true`;
-    },
+    previewUrl: story => story.getUrl(true),
+    url: story => story.getUrl(),
     hash: story => story.pushId,
     path: story => story.getPath(),
     ...userAttributionFields,

--- a/src/schema/advertiser.js
+++ b/src/schema/advertiser.js
@@ -1,4 +1,5 @@
 const { Schema } = require('mongoose');
+const { isURL } = require('validator');
 const slug = require('slug');
 const connection = require('../connections/mongoose/instance');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
@@ -18,6 +19,20 @@ const schema = new Schema({
     type: String,
     required: true,
     trim: true,
+  },
+  website: {
+    type: String,
+    trim: true,
+    validate: {
+      validator(v) {
+        if (!v) return true;
+        return isURL(v, {
+          protocols: ['http', 'https'],
+          require_protocol: true,
+        });
+      },
+      message: 'Invalid publisher website URL for {VALUE}',
+    },
   },
 }, { timestamps: true });
 

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -1,5 +1,5 @@
 const { Schema } = require('mongoose');
-const { isFQDN } = require('validator');
+const { isFQDN, isURL } = require('validator');
 const env = require('../env');
 const connection = require('../connections/mongoose/instance');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
@@ -27,6 +27,20 @@ const schema = new Schema({
         return isFQDN(String(v));
       },
       message: 'Invalid domain name: {VALUE}',
+    },
+  },
+  website: {
+    type: String,
+    required: true,
+    trim: true,
+    validate: {
+      validator(v) {
+        return isURL(v, {
+          protocols: ['http', 'https'],
+          require_protocol: true,
+        });
+      },
+      message: 'Invalid publisher website URL for {VALUE}',
     },
   },
 }, { timestamps: true });

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -59,6 +59,8 @@ schema.pre('save', async function checkDelete() {
   if (placements) throw new Error('You cannot delete a publisher that has related placements.');
   const topics = await connection.model('topic').countActive({ publisherId: this.id });
   if (topics) throw new Error('You cannot delete a publisher that has related topics.');
+  const stories = await connection.model('story').countActive({ publisherId: this.id });
+  if (stories) throw new Error('You cannot delete a publisher that has related stories.');
 });
 
 schema.pre('save', async function updatePlacements() {

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -92,11 +92,10 @@ schema.method('getPath', async function getPath() {
   return `${advertiser.slug}/${this.slug}/${this.id}`;
 });
 
-schema.method('getUrl', async function getUrl(preview) {
+schema.method('getUrl', async function getUrl(params) {
   const account = await accountService.retrieve();
   const path = await this.getPath();
-  const url = `${storyUrl(account.storyUri, path)}`;
-  return preview ? `${url}/?preview=true` : url;
+  return storyUrl(account.storyUri, path, params);
 });
 
 schema.pre('save', async function checkDelete() {

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -54,6 +54,12 @@ schema.plugin(referencePlugin, {
   modelName: 'advertiser',
   options: { required: true, es_indexed: true, es_type: 'keyword' },
 });
+schema.plugin(referencePlugin, {
+  name: 'publisherId',
+  connection,
+  modelName: 'publisher',
+  options: { required: true },
+});
 schema.plugin(deleteablePlugin, {
   es_indexed: true,
   es_type: 'boolean',

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -85,6 +85,11 @@ schema.virtual('status').get(function getStatus() {
   return 'Draft';
 });
 
+schema.method('getPath', async function getPath() {
+  const advertiser = await connection.model('advertiser').findById(this.advertiserId);
+  return `${advertiser.slug}/${this.slug}/${this.id}`;
+});
+
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
   const count = await connection.model('campaign').countActive({ storyId: this.id });

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -12,6 +12,8 @@ const {
   searchablePlugin,
   userAttributionPlugin,
 } = require('../plugins');
+const storyUrl = require('../utils/story-url');
+const accountService = require('../services/account');
 
 const schema = new Schema({
   title: {
@@ -88,6 +90,13 @@ schema.virtual('status').get(function getStatus() {
 schema.method('getPath', async function getPath() {
   const advertiser = await connection.model('advertiser').findById(this.advertiserId);
   return `${advertiser.slug}/${this.slug}/${this.id}`;
+});
+
+schema.method('getUrl', async function getUrl(preview) {
+  const account = await accountService.retrieve();
+  const path = await this.getPath();
+  const url = `${storyUrl(account.storyUri, path)}`;
+  return preview ? `${url}/?preview=true` : url;
 });
 
 schema.pre('save', async function checkDelete() {

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -109,7 +109,7 @@ module.exports = {
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
     const account = await accountService.retrieve();
-    const path = await Story.findById(storyId, { body: 0 });
+    const { path } = await Story.findById(storyId, { body: 0 });
     return storyUrl(publisher.customUri || account.storyUri, path, { pubid: publisherId });
   },
 

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -109,7 +109,8 @@ module.exports = {
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
     const account = await accountService.retrieve();
-    const { path } = await Story.findById(storyId, { body: 0 });
+    const story = await Story.findById(storyId, { body: 0 });
+    const path = await story.getPath();
     return storyUrl(publisher.customUri || account.storyUri, path, { pubid: publisherId });
   },
 

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -110,7 +110,7 @@ module.exports = {
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
     const account = await accountService.retrieve();
     const path = await Story.findById(storyId, { body: 0 });
-    return storyUrl(publisher.customUri || account.storyUri, path);
+    return storyUrl(publisher.customUri || account.storyUri, path, { pubid: publisherId });
   },
 
   /**

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -7,6 +7,7 @@ const Campaign = require('../models/campaign');
 const Publisher = require('../models/publisher');
 const Image = require('../models/image');
 const Placement = require('../models/placement');
+const Story = require('../models/story');
 const Template = require('../models/template');
 const Utils = require('../utils');
 const storyUrl = require('../utils/story-url');
@@ -108,7 +109,8 @@ module.exports = {
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
     const account = await accountService.retrieve();
-    return storyUrl(publisher.customUri || account.storyUri, storyId);
+    const path = await Story.findById(storyId, { body: 0 });
+    return storyUrl(publisher.customUri || account.storyUri, path);
   },
 
   /**

--- a/src/utils/story-url.js
+++ b/src/utils/story-url.js
@@ -1,1 +1,9 @@
-module.exports = (uri, path) => `${uri}/${path}`;
+const querystring = require('querystring');
+
+module.exports = (uri, path, params) => {
+  const url = `${uri.replace(/\/+$/g, '')}/${path.replace(/^\/+/g, '').replace(/\/+$/g, '')}`;
+  if (params && typeof params === 'object') {
+    return `${url}/?${querystring.stringify(params)}`;
+  }
+  return url;
+};

--- a/src/utils/story-url.js
+++ b/src/utils/story-url.js
@@ -1,1 +1,1 @@
-module.exports = (uri, storyId) => `${uri}/story/${storyId}`;
+module.exports = (uri, path) => `${uri}/${path}`;

--- a/test/services/campaign-delivery.spec.js
+++ b/test/services/campaign-delivery.spec.js
@@ -13,7 +13,7 @@ describe('services/campaign-delivery', function() {
       });
 
       sandbox.stub(Story, 'findById').resolves({
-        path: 'foo/bar',
+        getPath: () => Promise.resolve('foo/bar'),
       });
 
       sandbox.stub(Publisher, 'findById')

--- a/test/services/campaign-delivery.spec.js
+++ b/test/services/campaign-delivery.spec.js
@@ -1,0 +1,44 @@
+const campaignDelivery = require('../../src/services/campaign-delivery');
+const accountService = require('../../src/services/account');
+const { Publisher, Story } = require('../../src/models');
+
+const sandbox = sinon.createSandbox();
+
+
+describe('services/campaign-delivery', function() {
+  describe('#getClickUrl', function() {
+    beforeEach(function() {
+      sandbox.stub(accountService, 'retrieve').resolves({
+        storyUri: 'https://www.google.com',
+      });
+
+      sandbox.stub(Story, 'findById').resolves({
+        path: 'foo/bar',
+      });
+
+      sandbox.stub(Publisher, 'findById')
+        .withArgs('1234').resolves({ id: '1234' })
+        .withArgs('5678').resolves({ id: '5678', customUri: 'https://www.msn.com' })
+      ;
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should return the provided `url` when no `storyId` is set.', async function() {
+      await expect(campaignDelivery.getClickUrl({ url: 'http://www.foo.com' })).to.eventually.equal('http://www.foo.com');
+      sandbox.assert.notCalled(accountService.retrieve);
+    });
+    it('should return the account based URI', async function() {
+      await expect(campaignDelivery.getClickUrl({ storyId: '1234' }, { publisherId: '1234' }))
+        .to.eventually.equal('https://www.google.com/foo/bar/?pubid=1234')
+      ;
+    });
+    it('should return the publisher based URI', async function() {
+      await expect(campaignDelivery.getClickUrl({ storyId: '1234' }, { publisherId: '5678' }))
+        .to.eventually.equal('https://www.msn.com/foo/bar/?pubid=5678')
+      ;
+    });
+  });
+});

--- a/test/utils/story-url.spec.js
+++ b/test/utils/story-url.spec.js
@@ -10,11 +10,14 @@ describe('utils/story-url', function() {
   it('should strip slashes properly', async function() {
     expect(storyUrl('https://www.google.com//', '//foo/bar/')).to.equal('https://www.google.com/foo/bar');
   });
-  it('should set query paramters', async function() {
+  it('should set query parameters', async function() {
     const params = {
       foo: 'bar',
       baz: true,
     }
     expect(storyUrl('https://www.google.com', 'foo/bar//', params)).to.equal('https://www.google.com/foo/bar/?foo=bar&baz=true');
+  });
+  it('should not set the parameters when `params` is not an object.', async function() {
+    expect(storyUrl('https://www.google.com', 'foo/bar', '1234')).to.equal('https://www.google.com/foo/bar');
   });
 });

--- a/test/utils/story-url.spec.js
+++ b/test/utils/story-url.spec.js
@@ -1,0 +1,20 @@
+const storyUrl = require('../../src/utils/story-url');
+
+describe('utils/story-url', function() {
+  it('should export a function.', async function() {
+    expect(storyUrl).to.be.a('function');
+  });
+  it('should apply the URI and path', async function() {
+    expect(storyUrl('https://www.google.com', 'foo/bar')).to.equal('https://www.google.com/foo/bar');
+  });
+  it('should strip slashes properly', async function() {
+    expect(storyUrl('https://www.google.com//', '//foo/bar/')).to.equal('https://www.google.com/foo/bar');
+  });
+  it('should set query paramters', async function() {
+    const params = {
+      foo: 'bar',
+      baz: true,
+    }
+    expect(storyUrl('https://www.google.com', 'foo/bar//', params)).to.equal('https://www.google.com/foo/bar/?foo=bar&baz=true');
+  });
+});


### PR DESCRIPTION
- Add `publisher` field to `Story`: services as the primary publisher
- Add `website` field to `Advertiser` (optional) and `Publisher` (required)
- Adjust story URL generation
- Add `pubid` context to story campaign URLs
- Add `storySitemap` query and corresponding `StorySitemapItem` type

### Migration Notes
#### publishers
Add `website` to each model
#### stories
Add `publisherId` to each model