### PR TITLE
Upgrade newrelic to ^4.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mongoose-elasticsearch-xp": "^5.4.1",
     "multer": "^1.3.0",
     "multer-s3": "^2.7.0",
-    "newrelic": "^4.7.0",
+    "newrelic": "^4.8.0",
     "object-hash": "^1.2.0",
     "object-path": "^0.11.4",
     "passport": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3343,9 +3343,9 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-newrelic@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-4.7.0.tgz#9044848e1fc3c137aecb7497bf16923683773eff"
+newrelic@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-4.8.0.tgz#5068bb18575b4461c14e2c4642ae5da9bace08ad"
   dependencies:
     "@newrelic/koa" "^1.0.0"
     "@tyriar/fibonacci-heap" "^2.0.7"


### PR DESCRIPTION
It _should_ fix the mongodb instrumentation issue we’ve experienced.

See: https://discuss.newrelic.com/t/newrelic-mongodb-instrumentation-is-broken-and-logs-error/55326/17?u=jbare

P.S. Beverly Crusher, ftw!