### PR TITLE
RC 3.1 Tweaks

### DIFF
--- a/src/graph/definitions/account.graphql
+++ b/src/graph/definitions/account.graphql
@@ -21,6 +21,7 @@ type AccountSettings {
   id: String!
   cname: String
   reservePct: Int!
+  requiredCreatives: Int!
   googleAnalyticsId: String!
   siteVerificationMeta: String
 }
@@ -37,4 +38,5 @@ input AccountUpdatePayloadInput {
 
 input AccountUpdateSettingsInput {
   reservePct: Int!
+  requiredCreatives: Int!
 }

--- a/src/graph/definitions/campaign.graphql
+++ b/src/graph/definitions/campaign.graphql
@@ -60,6 +60,7 @@ type Campaign implements UserAttribution & Timestampable {
   requires: String
   deleted: Boolean!
   paused: Boolean!
+  requiredCreatives: Int!
   publishers(pagination: PaginationInput = {}, sort: PublisherSortInput = {}): PublisherConnection!
   url: String
   primaryImage: Image

--- a/src/graph/definitions/dashboard.graphql
+++ b/src/graph/definitions/dashboard.graphql
@@ -1,7 +1,8 @@
 type Query {
   dailyCampaignMetrics(day: Date!): DailyCampaignMetrics!
   dailyTotalMetrics(day: Date!): DailyTotalMetrics!
-  publisherMetricBreakouts(input: PublisherMetricsInput!): [PublisherBreakoutMetrics!]!
+  publisherMetricBreakouts(input: BreakoutMetricsInput!, sort: PublisherMetricsSortInput = {}): [PublisherBreakoutMetrics!]!
+  topicMetricBreakouts(input: BreakoutMetricsInput!, sort: TopicMetricsSortInput = {}): [TopicBreakoutMetrics!]!
 }
 
 type DailyCampaignMetrics {
@@ -19,22 +20,47 @@ type DailyTotalMetrics {
 }
 
 type PublisherBreakoutMetrics {
-  publisher: Publisher
-  placement: Placement
-  topic: Topic
+  publisherName: String!
   views: Int!
   clicks: Int!
   ctr: Float!
 }
 
-input PublisherMetricsInput {
-  startDay: Date!
-  endDay: Date!
-  breakout: PublisherMetricsBreakout!
+type TopicBreakoutMetrics {
+  topicName: String!
+  publisherName: String!
+  views: Int!
+  clicks: Int!
+  ctr: Float!
 }
 
-enum PublisherMetricsBreakout {
-  publisher
-  placement
-  topic
+input BreakoutMetricsInput {
+  startDay: Date!
+  endDay: Date!
+}
+
+input PublisherMetricsSortInput {
+  field: PublisherMetricsSortField!
+  order: Int! = -1
+}
+
+enum PublisherMetricsSortField {
+  publisherName
+  views
+  clicks
+  ctr
+}
+
+
+input TopicMetricsSortInput {
+  field: TopicMetricsSortField!
+  order: Int! = -1
+}
+
+enum TopicMetricsSortField {
+  topicName
+  publisherName
+  views
+  clicks
+  ctr
 }

--- a/src/graph/resolvers/account.js
+++ b/src/graph/resolvers/account.js
@@ -30,7 +30,9 @@ module.exports = {
       auth.checkAdmin();
       const { id, payload } = input;
       const account = await Account.strictFindById(id);
-      account.set(payload);
+      const { name, settings } = payload;
+      account.name = name;
+      account.set('settings.reservePct', settings.reservePct);
       return account.save();
     },
   },

--- a/src/graph/resolvers/account.js
+++ b/src/graph/resolvers/account.js
@@ -33,6 +33,7 @@ module.exports = {
       const { name, settings } = payload;
       account.name = name;
       account.set('settings.reservePct', settings.reservePct);
+      account.set('settings.requiredCreatives', settings.requiredCreatives);
       return account.save();
     },
   },

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -60,6 +60,7 @@ module.exports = {
     },
     metrics: campaign => analytics.retrieveMetrics({ cid: campaign._id }),
     reports: campaign => campaign,
+    creatives: campaign => campaign.creatives.filter(cre => !cre.deleted),
     createdBy: campaign => User.findById(campaign.createdById),
     updatedBy: campaign => User.findById(campaign.updatedById),
   },

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -171,7 +171,7 @@ module.exports = {
      */
     campaignsStartingSoon: (root, { pagination, sort }, { auth }) => {
       auth.check();
-      const start = moment().add(7, 'days').toDate();
+      const start = moment().add(14, 'days').toDate();
       const criteria = {
         deleted: false,
         'criteria.start': { $gte: new Date(), $lte: start },
@@ -184,7 +184,7 @@ module.exports = {
      */
     campaignsEndingSoon: (root, { pagination, sort }, { auth }) => {
       auth.check();
-      const end = moment().add(7, 'days').toDate();
+      const end = moment().add(14, 'days').toDate();
       const criteria = {
         deleted: false,
         ready: true,

--- a/src/graph/resolvers/dashboard.js
+++ b/src/graph/resolvers/dashboard.js
@@ -155,12 +155,15 @@ module.exports = {
           $project.pubid = '$_id';
           break;
         case 'placement':
-          groupId = '$pid';
-          $project.pid = '$_id';
+          groupId = { pid: '$pid', tid: '$tid', pubid: '$pubid' };
+          $project.pid = '$_id.pid';
+          $project.tid = '$_id.tid';
+          $project.pubid = '$_id.pubid';
           break;
         case 'topic':
-          groupId = '$tid';
-          $project.tid = '$_id';
+          groupId = { tid: '$tid', pubid: '$pubid' };
+          $project.tid = '$_id.tid';
+          $project.pubid = '$_id.pubid';
           break;
         default:
           throw new Error(`The breakout '${breakout}' is not supported.`);

--- a/src/graph/resolvers/dashboard.js
+++ b/src/graph/resolvers/dashboard.js
@@ -1,30 +1,10 @@
 const AnalyticsCampaign = require('../../models/analytics/campaign');
 const AnalyticsPlacement = require('../../models/analytics/placement');
 const Campaign = require('../../models/campaign');
-const Placement = require('../../models/placement');
 const Publisher = require('../../models/publisher');
-const Topic = require('../../models/topic');
 const campaignDelivery = require('../../services/campaign-delivery');
 
 module.exports = {
-  /**
-   *
-   */
-  PublisherBreakoutMetrics: {
-    publisher: ({ pubid }) => {
-      if (!pubid) return null;
-      return Publisher.findById({ _id: pubid });
-    },
-    placement: ({ pid }) => {
-      if (!pid) return null;
-      return Placement.findById({ _id: pid });
-    },
-    topic: ({ tid }) => {
-      if (!tid) return null;
-      return Topic.findById({ _id: tid });
-    },
-  },
-
   /**
    *
    */
@@ -127,62 +107,158 @@ module.exports = {
       };
     },
 
-    publisherMetricBreakouts: async (root, { input }, { auth }) => {
+    /**
+     *
+     */
+    publisherMetricBreakouts: async (root, { input, sort }, { auth }) => {
       auth.check();
-      const { startDay, endDay, breakout } = input;
+      const { startDay, endDay } = input;
 
-      const $project = {
-        _id: 0,
-        views: 1,
-        clicks: 1,
-        ctr: {
-          $cond: {
-            if: {
-              $eq: ['$views', 0],
-            },
-            then: 0,
-            else: {
-              $divide: ['$clicks', '$views'],
+      const pipeline = [
+        { $project: { _id: 1, name: 1 } },
+        {
+          $lookup: {
+            from: 'analytics-placements',
+            let: { publisherId: '$_id' },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: ['$pubid', '$$publisherId'] },
+                      { $gte: ['$day', startDay] },
+                      { $lte: ['$day', endDay] },
+                    ],
+                  },
+                },
+              },
+              {
+                $group: {
+                  _id: '$pubid',
+                  views: { $sum: '$view' },
+                  clicks: { $sum: '$click' },
+                },
+              },
+            ],
+            as: 'metrics',
+          },
+        },
+        {
+          $unwind: {
+            path: '$metrics',
+            preserveNullAndEmptyArrays: true,
+          },
+        },
+        {
+          $project: {
+            _id: 1,
+            publisherName: '$name',
+            views: { $ifNull: ['$metrics.views', 0] },
+            clicks: { $ifNull: ['$metrics.clicks', 0] },
+            ctr: {
+              $cond: {
+                if: { $lt: ['$metrics.views', 1] },
+                then: 0,
+                else: { $divide: ['$metrics.clicks', '$metrics.views'] },
+              },
             },
           },
         },
-      };
+        { $sort: { [sort.field]: sort.order } },
+      ];
 
-      let groupId;
-      switch (breakout) {
-        case 'publisher':
-          groupId = '$pubid';
-          $project.pubid = '$_id';
-          break;
-        case 'placement':
-          groupId = { pid: '$pid', tid: '$tid', pubid: '$pubid' };
-          $project.pid = '$_id.pid';
-          $project.tid = '$_id.tid';
-          $project.pubid = '$_id.pubid';
-          break;
-        case 'topic':
-          groupId = { tid: '$tid', pubid: '$pubid' };
-          $project.tid = '$_id.tid';
-          $project.pubid = '$_id.pubid';
-          break;
-        default:
-          throw new Error(`The breakout '${breakout}' is not supported.`);
-      }
+      return Publisher.aggregate(pipeline);
+    },
 
-      const pipeline = [];
-      pipeline.push({
-        $match: { day: { $gte: startDay, $lte: endDay } },
-      });
-      pipeline.push({
-        $group: {
-          _id: groupId,
-          views: { $sum: '$view' },
-          clicks: { $sum: '$click' },
+    /**
+     *
+     */
+    topicMetricBreakouts: async (root, { input, sort }, { auth }) => {
+      auth.check();
+      const { startDay, endDay } = input;
+
+      const pipeline = [
+        { $project: { _id: 1, name: 1 } },
+        {
+          $lookup: {
+            from: 'topics',
+            let: { publisherId: '$_id' },
+            pipeline: [
+              { $match: { $expr: { $eq: ['$publisherId', '$$publisherId'] } } },
+              { $project: { _id: 1, name: 1 } },
+            ],
+            as: 'topic',
+          },
         },
-      });
-      pipeline.push({ $project });
+        {
+          $project: {
+            _id: 1,
+            name: 1,
+            topic: {
+              $cond: {
+                if: { $gt: [{ $size: '$topic' }, 0] },
+                then: { $concatArrays: [[{ _id: false, name: '' }], '$topic'] },
+                else: [{ _id: false, name: '' }],
+              },
+            },
+          },
+        },
+        { $unwind: '$topic' },
+        {
+          $lookup: {
+            from: 'analytics-placements',
+            let: { publisherId: '$_id', topicId: '$topic._id' },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: ['$pubid', '$$publisherId'] },
+                      { $eq: [{ $ifNull: ['$tid', false] }, '$$topicId'] },
+                      { $gte: ['$day', startDay] },
+                      { $lte: ['$day', endDay] },
+                    ],
+                  },
+                },
+              },
+              {
+                $group: {
+                  _id: { pubid: '$pubid', tid: '$tid' },
+                  views: { $sum: '$view' },
+                  clicks: { $sum: '$click' },
+                },
+              },
+            ],
+            as: 'metrics',
+          },
+        },
+        {
+          $unwind: {
+            path: '$metrics',
+            preserveNullAndEmptyArrays: true,
+          },
+        },
+        {
+          $project: {
+            publisherId: '$_id',
+            publisherName: '$name',
+            topicId: '$topic._id',
+            topicName: '$topic.name',
+            views: { $ifNull: ['$metrics.views', 0] },
+            clicks: { $ifNull: ['$metrics.clicks', 0] },
+            ctr: {
+              $cond: {
+                if: { $lt: ['$metrics.views', 1] },
+                then: 0,
+                else: { $divide: ['$metrics.clicks', '$metrics.views'] },
+              },
+            },
+          },
+        },
+        { $sort: { [sort.field]: sort.order } },
+      ];
 
-      return AnalyticsPlacement.aggregate(pipeline);
+      return Publisher.aggregate(pipeline);
     },
   },
 };

--- a/src/schema/account.js
+++ b/src/schema/account.js
@@ -30,6 +30,10 @@ const settingsSchema = new Schema({
   bcc: {
     type: String,
   },
+  requiredCreatives: {
+    type: Number,
+    default: 1,
+  },
   session: {
     type: sessionSchema,
     default() {

--- a/src/schema/analytics/placement.js
+++ b/src/schema/analytics/placement.js
@@ -57,6 +57,7 @@ const schema = new Schema({
 
 schema.index({ pubid: 1 });
 schema.index({ tid: 1 });
+schema.index({ pubid: 1, tid: 1 });
 schema.index({ pid: 1, day: 1 }, { unique: true });
 
 schema.method('preAggregate', async function preAggregate(action) {

--- a/src/schema/campaign/creative.js
+++ b/src/schema/campaign/creative.js
@@ -15,6 +15,10 @@ const schema = new Schema({
     required: true,
     default: true,
   },
+  deleted: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 imagePlugin(schema, { fieldName: 'imageId' });

--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -175,6 +175,7 @@ schema.pre('save', async function setReady() {
 });
 
 schema.index({ advertiserId: 1 });
+schema.index({ 'creatives.deleted': 1 });
 schema.index({ name: 1, _id: 1 }, { unique: true });
 schema.index({ name: -1, _id: -1 }, { unique: true });
 schema.index({ updatedAt: 1, _id: 1 }, { unique: true });

--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -14,6 +14,7 @@ const {
   searchablePlugin,
   userAttributionPlugin,
 } = require('../../plugins');
+const accountService = require('../../services/account');
 
 const externalLinkSchema = new Schema({
   label: {
@@ -79,6 +80,10 @@ const schema = new Schema({
   creatives: [CreativeSchema],
   criteria: CriteriaSchema,
   externalLinks: [externalLinkSchema],
+  requiredCreatives: {
+    type: Number,
+    default: 1,
+  },
 }, { timestamps: true });
 
 setEntityFields(schema, 'name');
@@ -127,13 +132,16 @@ schema.method('getRequirements', async function getRequirements() {
     url,
     criteria,
     creatives,
+    requiredCreatives,
   } = this;
 
   const needs = [];
   const start = criteria.get('start');
   if (!start) needs.push('a start date');
   if (!criteria.get('placementIds.length')) needs.push('a placement');
-  if (!creatives.filter(cre => cre.active).length) needs.push('an active creative');
+  if (creatives.filter(cre => cre.active).length < requiredCreatives) {
+    needs.push(`at least ${requiredCreatives} active creative(s)`);
+  }
   if (storyId) {
     const story = await connection.model('story').findById(storyId);
     const storyNeed = 'an active story';
@@ -149,6 +157,14 @@ schema.method('getRequirements', async function getRequirements() {
     needs.push('a URL');
   }
   return needs.sort().join(', ');
+});
+
+schema.pre('validate', async function setRequiredCreatives() {
+  const account = await accountService.retrieve();
+  const requiredCreatives = account.get('settings.requiredCreatives');
+  if (this.isNew) {
+    this.requiredCreatives = requiredCreatives;
+  }
 });
 
 schema.pre('save', async function setAdvertiserForStory() {

--- a/src/services/account.js
+++ b/src/services/account.js
@@ -2,24 +2,16 @@ const objectPath = require('object-path');
 const Account = require('../models/account');
 const env = require('../env');
 
-let promise;
-
 module.exports = {
   /**
    * Retrieves the account from the database using its key.
    */
-  retrieve() {
-    const run = async () => {
-      const key = this.getKey();
-      if (!key) throw new Error('Unable to retrieve account: no account key was set.');
-      const account = await Account.findOne({ key });
-      if (!account) throw new Error(`No account found for key '${key}'`);
-      return account;
-    };
-    if (!promise) {
-      promise = run();
-    }
-    return promise;
+  async retrieve() {
+    const key = this.getKey();
+    if (!key) throw new Error('Unable to retrieve account: no account key was set.');
+    const account = await Account.findOne({ key });
+    if (!account) throw new Error(`No account found for key '${key}'`);
+    return account;
   },
 
   /**

--- a/src/services/campaign-creatives.js
+++ b/src/services/campaign-creatives.js
@@ -85,7 +85,7 @@ module.exports = {
   async findFor(campaignId, creativeId) {
     const campaign = await Campaign.strictFindActiveById(campaignId);
     const creative = campaign.creatives.id(creativeId);
-    if (!creative) throw new Error('No creative was found for the provided ID.');
+    if (!creative || creative.deleted) throw new Error('No creative was found for the provided ID.');
     return creative;
   },
 
@@ -100,7 +100,7 @@ module.exports = {
 
     const creative = campaign.creatives.id(creativeId);
     if (!creative) throw new Error('Unable to handle creative: no creative was found for the provided ID.');
-    creative.remove();
+    creative.deleted = true;
     return campaign.save();
   },
 };

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -115,7 +115,7 @@ module.exports = {
     const story = await Story.findById(storyId, { body: 0 });
     const path = await story.getPath();
     return storyUrl(publisher.customUri || account.storyUri, path, {
-      pubid: publisherId,
+      pubid: publisher.id,
       utm_source: 'NativeX',
       utm_medium: 'banner',
       utm_campaign: campaign.id,

--- a/test/services/campaign-creatives.spec.js
+++ b/test/services/campaign-creatives.spec.js
@@ -65,8 +65,8 @@ describe('services/campaign-creatives', function() {
       await expect(CampaignCreatives.removeFrom(campaign.id, creative.id)).to.eventually.be.an.instanceOf(Campaign);
 
       const found = await Campaign.findById(campaign.id);
-      expect(found.get('creatives').length).to.equal(length - 1);
-      expect(found.get('creatives').id(creative.id)).to.be.null;
+      expect(found.get('creatives').length).to.equal(length);
+      expect(found.get('creatives').id(creative.id).deleted).to.be.true;
     });
   });
 


### PR DESCRIPTION
- Extend starting/ending soon dates on dashboard to 14 days
- Soft-delete campaign creatives
- Use aggregation queries to handle publisher and topic breakouts on dashboard
- Ensure account service returns account directly from DB and not an in-memory promise
- Ensure account update does not overwrite existing settings
- Add `requiredCreatives` setting to account and apply to campaigns on create