### PR TITLE
Add support for "templateless" delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The above example is for illustrative purposes. An actual request would be simil
 When URL encoded: `opts=%7B%22n%22%3A1%2C%22cv%22%3A%7B%22foo%22%3A%22bar%22%2C%22key%22%3A%22value%22%7D%2C%22mv%22%3A%7B%22foo%22%3A%22bar%22%2C%22key%22%3A%22value%22%7D%2C%22fv%22%3A%7B%22foo%22%3A%22bar%22%2C%22key%22%3A%22value%22%7D%7D`
 
 ### "Templateless" Placement Delivery
-You can also request ads for a placement without rendering an ad or fallback template. Instead, this endpoint will return a JSON object representing the elements of the ad or fallback position. It is up to the consuming application to properly render its own template with the proper tracking attributes. Requests can be made via `GET /placement/elements/{pid}.json?opts={}`.
+You can also request ads for a placement without rendering an ad or fallback template. Instead, this endpoint will return a JSON object representing the elements of the ad (if found), container attributes, and click tracking attributes. It is up to the consuming application to properly render its own template and tracking attributes. Requests can be made via `GET /placement/elements/{pid}.json?opts={}`.
 
 Request options must sent as a URL encoded, compact JSON string, assigned to the value of the `opts` query string. All fields are optional.
 
@@ -163,6 +163,69 @@ encodeURIComponent(JSON.stringify({
     w: 75,
   },
 }));
+```
+
+#### Sample Response Without an Ad
+```json
+{
+  "ads": [
+    {
+      "placementId": "5cdb1909f41dfb0001fb2fdf",
+      "hasCampaign": false,
+      "attributes": {
+        "container": {
+          "data-fortnight-action": "view",
+          "data-fortnight-fields": "%7B%22uuid%22%3A%221ec9a389-05a9-4a6f-b73c-042cfd3cfc1a%22%2C%22pid%22%3A%225cdb1909f41dfb0001fb2fdf%22%2C%22kv%22%3A%7B%7D%7D",
+          "data-fortnight-timestamp": 1561411437193
+        },
+        "link": {
+          "data-fortnight-action": "click",
+          "data-fortnight-fields": "%7B%22uuid%22%3A%221ec9a389-05a9-4a6f-b73c-042cfd3cfc1a%22%2C%22pid%22%3A%225cdb1909f41dfb0001fb2fdf%22%2C%22kv%22%3A%7B%7D%7D"
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Sample Response With an Ad
+```json
+{
+  "ads": [
+    {
+      "placementId": "5cdb1909f41dfb0001fb2fdf",
+      "hasCampaign": true,
+      "attributes": {
+        "container": {
+          "data-fortnight-action": "view",
+          "data-fortnight-fields": "%7B%22uuid%22%3A%225419e57c-ae2e-4558-a480-14a87a9fa43c%22%2C%22pid%22%3A%225cdb1909f41dfb0001fb2fdf%22%2C%22kv%22%3A%7B%7D%7D",
+          "data-fortnight-timestamp": 1561469767859
+        },
+        "link": {
+          "data-fortnight-action": "click",
+          "data-fortnight-fields": "%7B%22uuid%22%3A%225419e57c-ae2e-4558-a480-14a87a9fa43c%22%2C%22pid%22%3A%225cdb1909f41dfb0001fb2fdf%22%2C%22kv%22%3A%7B%7D%7D"
+        }
+      },
+      "href": "https://www.waterworld.com/municipal/drinking-water/infrastructure-funding/article/14035021/epa-awards-2451000-to-minnesota-to-protect-public-drinking-water-systems",
+      "campaign": {
+        "id": "5d025dfce6eafd0001d5df63",
+        "name": "Endeavor Test Campaign",
+        "advertiserName": "Endeavor B2B",
+        "createdAt": 1560436220116,
+        "updatedAt": 1560436220116
+      },
+      "creative": {
+        "id": "5d025e5e4b58010001a246b2",
+        "title": "EPA awards $2,451,000 to Minnesota to protect public drinking water systems",
+        "teaser": "The funding will help protect 6,800 public water systems in Minnesota serving approximately 5.6 million people daily."
+      },
+      "image": {
+        "id": "5d113c7a16f0cf000106e469",
+        "src": "https://fortnight.imgix.net/ebm/5d113c7a16f0cf000106e469/beverage_bottle_drink_2101147.5d0965c10c2c8.png?crop=focalpoint&fit=crop&fp-x=0.52&fp-y=0.42"
+      }
+    }
+  ]
+}
 ```
 
 ### Campaign Status

--- a/README.md
+++ b/README.md
@@ -126,6 +126,45 @@ The above example is for illustrative purposes. An actual request would be simil
 `GET /placement/{pid}.html?opts={"n":1,"cv":{"foo":"bar","key":"value"},"mv":{"foo":"bar","key":"value"},"fv":{"foo":"bar","key":"value"}}`
 When URL encoded: `opts=%7B%22n%22%3A1%2C%22cv%22%3A%7B%22foo%22%3A%22bar%22%2C%22key%22%3A%22value%22%7D%2C%22mv%22%3A%7B%22foo%22%3A%22bar%22%2C%22key%22%3A%22value%22%7D%2C%22fv%22%3A%7B%22foo%22%3A%22bar%22%2C%22key%22%3A%22value%22%7D%7D`
 
+### "Templateless" Placement Delivery
+You can also request ads for a placement without rendering an ad or fallback template. Instead, this endpoint will return a JSON object representing the elements of the ad or fallback position. It is up to the consuming application to properly render its own template with the proper tracking attributes. Requests can be made via `GET /placement/elements/{pid}.json?opts={}`.
+
+Request options must sent as a URL encoded, compact JSON string, assigned to the value of the `opts` query string. All fields are optional.
+
+```js
+encodeURIComponent(JSON.stringify({
+  /**
+   * Optional.
+   * Specifies the number of campaigns that should be returned.
+   * The default value is `1` and cannot exceed `10` (a 400 response will be returned if the max is exceeded).
+   * The CSA will do its best to return the number requested, but is not guaranteed, based on inventory conditions.
+   */
+  n: 1,
+
+  /**
+   * Optional.
+   * The custom targting variables to send with the request - used for campaign targeting.
+   * Only custom variables that have been pre-defined in the system will be used.
+   * Any others will be ignored.
+   */
+  cv: {
+    foo: 'bar',
+    key: 'value',
+  },
+
+  /**
+   * Optional.
+   * Sets parameters (e.g. width, height, etc) to the creative's image.
+   * You cannont, however, override the focal point cropping options, as these are defined by the image itself.
+   */
+  image: {
+    // These mimic the options available from the Imgix API.
+    h: 75,
+    w: 75,
+  },
+}));
+```
+
 ### Campaign Status
 
 #### Flags
@@ -249,4 +288,3 @@ REST APIs, microservices, or databases."
 - [Mongoose](http://mongoosejs.com/docs/guide.html) - "elegant mongodb object modeling for node.js"
 - [Passport](http://www.passportjs.org/) - "Simple, unobtrusive authentication for Node.js"
 - [Bluebird](http://bluebirdjs.com/docs/getting-started.html) - "A full featured promise library with unmatched performance."
-

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     }
   },
   "dependencies": {
+    "@base-cms/image": "^0.9.22",
     "@godaddy/terminus": "^4.1.0",
     "@limit0/graphql-custom-types": "^1.0.1",
     "@limit0/mongoose-graphql-pagination": "^1.1.3",

--- a/src/app.js
+++ b/src/app.js
@@ -3,11 +3,16 @@ const passport = require('passport');
 const cors = require('cors');
 const authStrategies = require('./auth-strategies');
 const loadRouters = require('./routers');
+const { TRUSTED_PROXIES } = require('./env');
 
 const app = express();
 const CORS = cors();
 
-app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+const proxies = ['loopback', 'linklocal', 'uniquelocal'];
+if (TRUSTED_PROXIES) {
+  TRUSTED_PROXIES.split(',').map(p => p.trim()).filter(p => p).forEach(p => proxies.push(p));
+}
+app.set('trust proxy', proxies);
 app.disable('x-powered-by');
 
 // Set the auth strategies

--- a/src/delivery/build-attrs.js
+++ b/src/delivery/build-attrs.js
@@ -1,0 +1,6 @@
+const { keys } = Object;
+
+module.exports = attrs => keys(attrs).map((key) => {
+  const value = attrs[key];
+  return `${key}="${value}"`;
+}).join(' ');

--- a/src/delivery/build-fields.js
+++ b/src/delivery/build-fields.js
@@ -1,0 +1,1 @@
+module.exports = fields => encodeURIComponent(JSON.stringify(fields));

--- a/src/delivery/container-attributes.js
+++ b/src/delivery/container-attributes.js
@@ -1,0 +1,14 @@
+const buildAttrs = require('./build-attrs');
+const buildFields = require('./build-fields');
+const extractFields = require('./extract-fields');
+
+module.exports = (data, flatten = false) => {
+  const fields = extractFields(data);
+  const attrs = {
+    'data-fortnight-action': 'view',
+    'data-fortnight-fields': buildFields(fields),
+    'data-fortnight-timestamp': (new Date()).getTime(),
+  };
+  if (!flatten) return attrs;
+  return buildAttrs(attrs);
+};

--- a/src/delivery/extract-fields.js
+++ b/src/delivery/extract-fields.js
@@ -1,0 +1,18 @@
+module.exports = (data = {}) => {
+  const {
+    pid,
+    uuid,
+    kv,
+    campaign,
+    creative,
+  } = data;
+  const cid = campaign ? campaign.id : undefined;
+  const cre = creative ? creative.id : undefined;
+  return {
+    uuid,
+    pid,
+    cid,
+    cre,
+    kv,
+  };
+};

--- a/src/delivery/tracked-link-attributes.js
+++ b/src/delivery/tracked-link-attributes.js
@@ -1,0 +1,13 @@
+const buildAttrs = require('./build-attrs');
+const buildFields = require('./build-fields');
+const extractFields = require('./extract-fields');
+
+module.exports = (data, flatten = false) => {
+  const fields = extractFields(data);
+  const attrs = {
+    'data-fortnight-action': 'click',
+    'data-fortnight-fields': buildFields(fields),
+  };
+  if (!flatten) return attrs;
+  return buildAttrs(attrs);
+};

--- a/src/env.js
+++ b/src/env.js
@@ -64,4 +64,5 @@ module.exports = cleanEnv(process.env, {
   REDIS_DSN: redisdsn({ desc: 'The Redis DSN to connect to.' }),
   SENDGRID_API_KEY: nonemptystr({ desc: 'The SendGrid API key for sending email.' }),
   SENDGRID_FROM: nonemptystr({ desc: 'The from name to use when sending email via SendGrid, e.g. Foo <foo@bar.com>' }),
+  TRUSTED_PROXIES: str({ desc: 'A comma seperated list of trusted proxy IP addresses.', default: '' }),
 });

--- a/src/handlebars.js
+++ b/src/handlebars.js
@@ -1,57 +1,29 @@
 const handlebars = require('handlebars');
 const moment = require('moment');
+const containerAttributes = require('./delivery/container-attributes');
+const trackedLinkAttributes = require('./delivery/tracked-link-attributes');
+const buildAttrs = require('./delivery/build-attrs');
 
 handlebars.registerHelper('moment-format', (date, format) => moment(date).format(format));
 handlebars.registerHelper('get-timestamp', () => (new Date()).getTime());
 
-const buildFields = fields => encodeURIComponent(JSON.stringify(fields));
-const buildAttrs = keyValues => keyValues.map(o => `data-fortnight-${o.key}="${o.value}"`).join(' ');
-
-const extractFields = (context) => {
-  const { data } = context;
-  const { root } = data || {};
-  const {
-    pid,
-    uuid,
-    kv,
-    campaign,
-    creative,
-  } = root || {};
-  const cid = campaign ? campaign.id : undefined;
-  const cre = creative ? creative.id : undefined;
-  return {
-    uuid,
-    pid,
-    cid,
-    cre,
-    kv,
-  };
-};
-
 handlebars.registerHelper('build-container-attributes', (context) => {
-  const fields = extractFields(context);
-  const keyValues = [
-    { key: 'action', value: 'view' },
-    { key: 'fields', value: buildFields(fields) },
-    { key: 'timestamp', value: (new Date()).getTime() },
-  ];
+  const { data = {} } = context;
+  const { root } = data;
 
-  const attrs = buildAttrs(keyValues);
+  const attrs = containerAttributes(root, true);
   return new handlebars.SafeString(attrs);
 });
 
 handlebars.registerHelper('tracked-link', function trackedLink(context) {
-  const { hash } = context;
-  const fields = extractFields(context);
-  const keyValues = [
-    { key: 'action', value: 'click' },
-    { key: 'fields', value: buildFields(fields) },
-  ];
-  const attrs = [];
-  attrs.push(Object.keys(hash).map(name => `${name}="${hash[name]}"`).join(' '));
-  attrs.push(buildAttrs(keyValues));
+  const { hash, data = {} } = context;
+  const { root } = data;
 
-  return new handlebars.SafeString(`<a ${attrs.join(' ')}>${context.fn(this)}</a>`);
+  const attrs = trackedLinkAttributes(root, false);
+  Object.keys(hash).forEach((name) => {
+    attrs[name] = hash[name];
+  });
+  return new handlebars.SafeString(`<a ${buildAttrs(attrs)}>${context.fn(this)}</a>`);
 });
 
 /**

--- a/src/routers/placement.js
+++ b/src/routers/placement.js
@@ -36,8 +36,9 @@ router.get('/elements/:pid.json', (req, res) => {
   const {
     n,
     cv,
+    image,
   } = CampaignDelivery.parseOptions(req.query.opts);
-  const vars = { custom: cv };
+  const vars = { custom: cv, image };
 
   const { NODE_ENV } = env;
   const protocol = NODE_ENV === 'production' ? 'https' : req.protocol;

--- a/src/schema/image.js
+++ b/src/schema/image.js
@@ -65,11 +65,16 @@ schema.methods.getKey = async function getKey() {
   return `${key}/${this.id}/${this.filename}`;
 };
 
-schema.methods.getSrc = async function getSrc() {
+schema.methods.getSrc = async function getSrc(withFocalPoint) {
   // The image src, for use with `img` elements.
   // Generated from the imgix url, the encoded account key, the id, and the encoded filename.
   const { key } = await accountService.retrieve();
-  return `${IMGIX_URL}/${encodeURIComponent(key)}/${this.id}/${encodeURIComponent(this.filename)}`;
+  const src = `${IMGIX_URL}/${encodeURIComponent(key)}/${this.id}/${encodeURIComponent(this.filename)}`;
+  if (!withFocalPoint) return src;
+  // Append the focal point, if present.
+  const { focalPoint = {} } = this;
+  const { x = 0.5, y = 0.5 } = focalPoint;
+  return `${src}?format=auto&crop=focalPoint&fit=crop&fp-x=${x}&fp-y=${y}`;
 };
 
 module.exports = schema;

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -206,7 +206,7 @@ module.exports = {
     userAgent,
     ipAddress,
     num = 1,
-    vars = { custom: {} },
+    vars = { custom: {}, image: {} },
   } = {}) {
     const placement = await this.getPlacement({ placementId });
     const account = await accountService.retrieve();
@@ -231,6 +231,7 @@ module.exports = {
         campaign,
         placement,
         event,
+        vars,
       });
     }));
   },
@@ -404,6 +405,7 @@ module.exports = {
     campaign,
     placement,
     event,
+    vars,
   }) {
     if (!campaign.id) {
       return this.buildFallbackDataFor({ placement, event });
@@ -414,7 +416,7 @@ module.exports = {
     }
 
     if (creative.image) {
-      creative.image.src = await creative.image.getSrc(true);
+      creative.image.src = await creative.image.getSrc(true, vars.image);
     }
 
     return {

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -12,6 +12,8 @@ const Template = require('../models/template');
 const Utils = require('../utils');
 const storyUrl = require('../utils/story-url');
 const accountService = require('./account');
+const containerAttributes = require('../delivery/container-attributes');
+const trackedLinkAttributes = require('../delivery/tracked-link-attributes');
 
 const { isArray } = Array;
 
@@ -27,6 +29,13 @@ module.exports = {
     } catch (e) {
       return {};
     }
+  },
+
+  parseLimit(num) {
+    const limit = num > 0 ? parseInt(num, 10) : 1;
+    if (limit > 10) throw createError(400, 'You cannot return more than 10 ads in one request.');
+    if (limit > 1) throw createError(501, 'Requesting more than one ad in a request is not yet implemented.');
+    return limit;
   },
 
   /**
@@ -101,6 +110,27 @@ module.exports = {
     return this.selectCampaigns(campaigns, limit);
   },
 
+  async queryCampaignsFor({
+    placement,
+    account,
+    limit,
+    keyValues,
+  }) {
+    const rp = placement.get('reservePct');
+    const ap = account.get('settings.reservePct');
+    const reservePct = (rp || ap || 0) / 100;
+
+    const campaigns = Math.random() >= reservePct
+      ? await this.queryCampaigns({
+        startDate: new Date(),
+        placementId: placement.id,
+        keyValues,
+        limit,
+      }) : [];
+    this.fillWithFallbacks(campaigns, limit);
+    return campaigns;
+  },
+
   /**
    * Determines the URL for the campaign.
    *
@@ -140,13 +170,7 @@ module.exports = {
     return shuffled.slice(0, limit);
   },
 
-  /**
-   *
-   * @param {object} params
-   * @param {string} params.placementId
-   * @return {Promise}
-   */
-  async getPlacementAndTemplate({ placementId } = {}) {
+  async getPlacement({ placementId } = {}) {
     if (!placementId) throw createError(400, 'No placement ID was provided.');
 
     const placement = await Placement.findOne({ _id: placementId }, {
@@ -156,6 +180,17 @@ module.exports = {
       reservePct: 1,
     });
     if (!placement) throw createError(404, `No placement exists for ID '${placementId}'`);
+    return placement;
+  },
+
+  /**
+   *
+   * @param {object} params
+   * @param {string} params.placementId
+   * @return {Promise}
+   */
+  async getPlacementAndTemplate({ placementId } = {}) {
+    const placement = await this.getPlacement({ placementId });
 
     const template = await Template.findOne({ _id: placement.templateId }, {
       html: 1,
@@ -164,6 +199,40 @@ module.exports = {
     if (!template) throw createError(404, `No template exists for ID '${placement.templateId}'`);
 
     return { placement, template };
+  },
+
+  async elementsFor({
+    placementId,
+    userAgent,
+    ipAddress,
+    num = 1,
+    vars = { custom: {} },
+  } = {}) {
+    const placement = await this.getPlacement({ placementId });
+    const account = await accountService.retrieve();
+
+    const limit = this.parseLimit(num);
+    const campaigns = await this.queryCampaignsFor({
+      account,
+      placement,
+      limit,
+      keyValues: vars.custom,
+    });
+
+    return Promise.all(campaigns.map((campaign) => {
+      const event = this.createRequestEvent({
+        cid: campaign.id,
+        pid: placement.id,
+        ua: userAgent,
+        kv: vars.custom,
+        ip: ipAddress,
+      });
+      return this.buildElementsFor({
+        campaign,
+        placement,
+        event,
+      });
+    }));
   },
 
   /**
@@ -186,22 +255,13 @@ module.exports = {
     const { placement, template } = await this.getPlacementAndTemplate({ placementId });
     const account = await accountService.retrieve();
 
-    const limit = num > 0 ? parseInt(num, 10) : 1;
-    if (limit > 10) throw createError(400, 'You cannot return more than 10 ads in one request.');
-    if (limit > 1) throw createError(501, 'Requesting more than one ad in a request is not yet implemented.');
-
-    const rp = placement.get('reservePct');
-    const ap = account.get('settings.reservePct');
-    const reservePct = (rp || ap || 0) / 100;
-
-    const campaigns = Math.random() >= reservePct
-      ? await this.queryCampaigns({
-        startDate: new Date(),
-        placementId: placement.id,
-        keyValues: vars.custom,
-        limit,
-      }) : [];
-    this.fillWithFallbacks(campaigns, limit);
+    const limit = this.parseLimit(num);
+    const campaigns = await this.queryCampaignsFor({
+      account,
+      placement,
+      limit,
+      keyValues: vars.custom,
+    });
 
     return Promise.all(campaigns.map((campaign) => {
       const event = this.createRequestEvent({
@@ -286,6 +346,34 @@ module.exports = {
     return ad;
   },
 
+  buildHTMLAttributes({ event }) {
+    const {
+      pid,
+      uuid,
+      kv,
+    } = event;
+    return {
+      container: containerAttributes({
+        pid,
+        uuid,
+        kv,
+      }),
+      link: trackedLinkAttributes({
+        pid,
+        uuid,
+        kv,
+      }),
+    };
+  },
+
+  buildFallbackDataFor({ placement, event }) {
+    return {
+      placementId: placement.id,
+      hasCampaign: false,
+      attributes: this.buildHTMLAttributes({ event }),
+    };
+  },
+
   /**
    * Rotates a campaign's creatives randomly.
    * Eventually could use some sort of weighting criteria.
@@ -310,6 +398,48 @@ module.exports = {
     const { imageId } = creative;
     if (imageId) creative.image = await Image.findById(imageId);
     return creative;
+  },
+
+  async buildElementsFor({
+    campaign,
+    placement,
+    event,
+  }) {
+    if (!campaign.id) {
+      return this.buildFallbackDataFor({ placement, event });
+    }
+    const creative = await this.getCreativeFor(campaign);
+    if (!creative) {
+      return this.buildFallbackDataFor({ placement, event });
+    }
+
+    if (creative.image) {
+      creative.image.src = await creative.image.getSrc(true);
+    }
+
+    return {
+      placementId: placement.id,
+      hasCampaign: true,
+      attributes: this.buildHTMLAttributes({ event }),
+      href: await this.getClickUrl(campaign, placement, creative),
+      campaign: {
+        id: campaign.id,
+        name: campaign.name,
+        advertiserName: campaign.advertiserName,
+        createdAt: campaign.createdAt ? campaign.createdAt.getTime() : null,
+        updatedAt: campaign.updatedAt ? campaign.createdAt.getTime() : null,
+      },
+      creative: {
+        id: creative.id,
+        title: creative.title,
+        teaser: creative.teaser,
+      },
+      image: creative.image ? {
+        id: creative.image.id,
+        src: creative.image.src,
+        alt: creative.image.alt,
+      } : {},
+    };
   },
 
   async buildAdFor({

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,20 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@base-cms/image@^0.9.22":
+  version "0.9.22"
+  resolved "https://registry.yarnpkg.com/@base-cms/image/-/image-0.9.22.tgz#dcc220c3702bf45f73c055085af0c38e9af20cfe"
+  integrity sha512-DnM4Mh3fOoiyjqIUNbHI3HYQXEiiopqM5g4v324wMwY01HxK7vQHK8/j6dlyUE7XkeexADbiGYq/ePxIKLMusA==
+  dependencies:
+    "@base-cms/inflector" "^0.9.0"
+
+"@base-cms/inflector@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@base-cms/inflector/-/inflector-0.9.0.tgz#a5ae8968c82369b176100b6c8b4d06220a104995"
+  integrity sha512-exkUC8BzB8Sfb/LP0uUu1/yxTctY3KjeCuXNXJ7LpSUbXIopTERu09d+A3zg3Cq9ljB0jDqFVrzmjO6La54ZYg==
+  dependencies:
+    inflected "^2.0.4"
+
 "@godaddy/terminus@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@godaddy/terminus/-/terminus-4.1.0.tgz#9f7883ed0a8444400d3f9b52f0b2b5fe68b28bd3"
@@ -2694,6 +2708,11 @@ ignore@^4.0.6:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+inflected@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.0.4.tgz#323770961ccbe992a98ea930512e9a82d3d3ef77"
+  integrity sha512-HQPzFLTTUvwfeUH6RAGjD8cHS069mBqXG5n4qaxX7sJXBhVQrsGgF+0ZJGkSuN6a8pcUWB/GXStta11kKi/WvA==
 
 inflection@^1.12.0:
   version "1.12.0"


### PR DESCRIPTION
Placement delivery now supports returning a JSON object representing the position/campaign data without rendering the ad (or fallback) template directly. This allows for a consuming application to control rendering "on-the-fly" without having to update the templates directly defined on the placement.

See the additions to the `README.md` file for more information.