### PR TITLE
Ensure campaign and creative fields are set

### DIFF
--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -347,7 +347,7 @@ module.exports = {
     return ad;
   },
 
-  buildHTMLAttributes({ event }) {
+  buildHTMLAttributes({ event, campaign, creative }) {
     const {
       pid,
       uuid,
@@ -358,11 +358,15 @@ module.exports = {
         pid,
         uuid,
         kv,
+        campaign,
+        creative,
       }),
       link: trackedLinkAttributes({
         pid,
         uuid,
         kv,
+        campaign,
+        creative,
       }),
     };
   },
@@ -422,7 +426,7 @@ module.exports = {
     return {
       placementId: placement.id,
       hasCampaign: true,
-      attributes: this.buildHTMLAttributes({ event }),
+      attributes: this.buildHTMLAttributes({ event, campaign, creative }),
       href: await this.getClickUrl(campaign, placement, creative),
       campaign: {
         id: campaign.id,


### PR DESCRIPTION
Ensures that the `cre` and `cid` fields are included in the `data-fortnight-fields` value within the placement elements JSON response.

![image](https://user-images.githubusercontent.com/3289485/62640388-18977700-b907-11e9-92fd-5330aa20765f.png)
