### PR TITLE
Add rel="nofollow" to tracked campaign links

### DIFF
--- a/src/delivery/tracked-link-attributes.js
+++ b/src/delivery/tracked-link-attributes.js
@@ -8,6 +8,7 @@ module.exports = (data, flatten = false) => {
     'data-fortnight-action': 'click',
     'data-fortnight-fields': buildFields(fields),
   };
+  if (data.campaign) attrs.rel = 'nofollow';
   if (!flatten) return attrs;
   return buildAttrs(attrs);
 };

--- a/src/handlebars.js
+++ b/src/handlebars.js
@@ -21,7 +21,7 @@ handlebars.registerHelper('tracked-link', function trackedLink(context) {
 
   const attrs = trackedLinkAttributes(root, false);
   Object.keys(hash).forEach((name) => {
-    attrs[name] = hash[name];
+    if (!attrs[name]) attrs[name] = hash[name];
   });
   return new handlebars.SafeString(`<a ${buildAttrs(attrs)}>${context.fn(this)}</a>`);
 });

--- a/src/handlebars.js
+++ b/src/handlebars.js
@@ -23,6 +23,9 @@ handlebars.registerHelper('tracked-link', function trackedLink(context) {
   Object.keys(hash).forEach((name) => {
     if (!attrs[name]) attrs[name] = hash[name];
   });
+  if (hash.target && hash.target === '_blank') {
+    attrs.rel = attrs.rel ? `${attrs.rel} noopener` : 'noopener';
+  }
   return new handlebars.SafeString(`<a ${buildAttrs(attrs)}>${context.fn(this)}</a>`);
 });
 


### PR DESCRIPTION
- Does not apply to fallbacks
- Setting a `rel` value in a template will have no effect
- If `target="_blank"` is present in the template's tracked-link, then also append `noopener` to the `rel` attribute.