### PR TITLE
Fix metrics/reports for cloned campaigns

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,17 @@
+{
+  "projects": {
+    "fortnight-graph": {
+      "schemaPath": "schema.graphql",
+      "extensions": {
+        "endpoints": {
+          "dev": {
+            "url": "http://0.0.0.0:8100/graph"
+          },
+          "production-ebm": {
+            "url": "https://ebm.native-x.io/graph"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "plugin.mandatory: analysis-phonetic"
+      - "plugin.mandatory:analysis-phonetic"
       - "logger.level=WARN"
     volumes:
       - esdata:/usr/share/elasticsearch/data

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -98,7 +98,7 @@ module.exports = {
    */
   CampaignCreativeReports: {
     byDay: (creative, { startDate, endDate }) => {
-      const criteria = { cre: creative._id, cid: creative.cid };
+      const criteria = { cre: creative._id, cid: creative.campaignId };
       return analytics.runCampaignByDayReport(criteria, { startDate, endDate });
     },
   },

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -88,7 +88,8 @@ module.exports = {
 
   CampaignCreative: {
     image: creative => Image.findById(creative.imageId),
-    metrics: ({ _id: cre, cid }) => analytics.retrieveMetrics({ cre, cid }),
+    metrics: creative => analytics
+      .retrieveMetrics({ cre: creative._id, cid: creative.campaignId }),
     reports: creative => creative,
   },
 

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -88,7 +88,7 @@ module.exports = {
 
   CampaignCreative: {
     image: creative => Image.findById(creative.imageId),
-    metrics: creative => analytics.retrieveMetrics({ cre: creative._id }),
+    metrics: ({ _id: cre, cid }) => analytics.retrieveMetrics({ cre, cid }),
     reports: creative => creative,
   },
 
@@ -97,7 +97,7 @@ module.exports = {
    */
   CampaignCreativeReports: {
     byDay: (creative, { startDate, endDate }) => {
-      const criteria = { cre: creative._id };
+      const criteria = { cre: creative._id, cid: creative.cid };
       return analytics.runCampaignByDayReport(criteria, { startDate, endDate });
     },
   },

--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -134,7 +134,8 @@ schema.method('clone', async function clone(user) {
     name: `${this.name} copy`,
   };
   ['id', '_id', 'pushId', 'createdAt', 'updatedAt', 'updatedBy', 'createdBy'].forEach(k => delete input[k]);
-  input.creatives.forEach(cre => cre._id = undefined); // eslint-disable-line
+  // eslint-disable-next-line no-param-reassign, no-return-assign
+  input.creatives.forEach(cre => cre._id = undefined);
 
   const doc = new Model(input);
   doc.setUserContext(user);

--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -134,6 +134,7 @@ schema.method('clone', async function clone(user) {
     name: `${this.name} copy`,
   };
   ['id', '_id', 'pushId', 'createdAt', 'updatedAt', 'updatedBy', 'createdBy'].forEach(k => delete input[k]);
+  input.creatives.forEach(cre => cre._id = undefined); // eslint-disable-line
 
   const doc = new Model(input);
   doc.setUserContext(user);

--- a/src/services/campaign-creatives.js
+++ b/src/services/campaign-creatives.js
@@ -86,7 +86,7 @@ module.exports = {
     const campaign = await Campaign.strictFindActiveById(campaignId);
     const creative = campaign.creatives.id(creativeId);
     if (!creative || creative.deleted) throw new Error('No creative was found for the provided ID.');
-    creative.cid = campaign._id;
+    creative.campaignId = campaign._id;
     return creative;
   },
 

--- a/src/services/campaign-creatives.js
+++ b/src/services/campaign-creatives.js
@@ -86,6 +86,7 @@ module.exports = {
     const campaign = await Campaign.strictFindActiveById(campaignId);
     const creative = campaign.creatives.id(creativeId);
     if (!creative || creative.deleted) throw new Error('No creative was found for the provided ID.');
+    creative.cid = campaign._id;
     return creative;
   },
 


### PR DESCRIPTION
[JIRA CS-3041](https://southcomm.atlassian.net/browse/CS-3041)

- Resolves reporting inaccuracies by ensuring the campaign ID is requested when querying for creative metrics or reports.
- Ensures that creative IDs will not collide when cloning a campaign