### PR TITLE
Fix TravisCI deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ _production-env: &production-env
 
 _production-job: &production-job
   stage: production
+  node_js: 10
   name: SERVICE_NAME
   script: scripts/deploy.js SERVICE_NAME
   install: skip
@@ -20,6 +21,7 @@ _production-job: &production-job
 
 # _staging-job: &staging-job
 #   stage: staging
+#   node_js: 10
 #   name: SERVICE_NAME
 #   script: scripts/deploy.js SERVICE_NAME
 #   install: skip
@@ -49,19 +51,15 @@ jobs:
       env:
         NODE_ENV: test
 
-    - stage: production-started
+    - <<: *production-job
+      stage: production-started
       name: Deployment Started
       script: npx @base-cms/website-deployment-tool notify-started
-      install: skip
-      env:
-        <<: *production-env
 
-    # - stage: staging-started
+    # - <<: *staging-job
+    #   stage: staging-started
     #   name: Deployment Started
     #   script: npx @base-cms/website-deployment-tool notify-started
-    #   install: skip
-    #   env:
-    #     <<: *staging-env
 
     #############################
     # vvv ADD SERVICES HERE vvv #
@@ -78,16 +76,12 @@ jobs:
     # ^^^ ADD SERVICES HERE ^^^ #
     #############################
 
-    - stage: production-finished
+    - <<: *production-job
+      stage: production-finished
       name: Deployment Finished
       script: npx @base-cms/website-deployment-tool notify-finished
-      install: skip
-      env:
-        <<: *production-env
 
-    # - stage: staging-finished
+    # - <<: *staging-job
+    #   stage: staging-finished
     #   name: Deployment Finished
     #   script: npx @base-cms/website-deployment-tool notify-finished
-    #   install: skip
-    #   env:
-    #     <<: *staging-env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fortnight-graph",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "src/index.js",
   "repository": "https://github.com/cygnusb2b/fortnight-graph.git",
   "author": "Jacob Bare <jacob@limit0.io>",


### PR DESCRIPTION
Updates build script to run deployment tooling under Node 10.x, while leaving the unit testing and packaging to run under Node 8.x.